### PR TITLE
#29 Create Route 53 record for K8s ingress ALB DNS

### DIFF
--- a/aws/arcgis-enterprise-k8s/README.md
+++ b/aws/arcgis-enterprise-k8s/README.md
@@ -64,9 +64,10 @@ Instructions:
 
 1. Provision or import SSL certificate for the ArcGIS Enterprise domain name into AWS Certificate Manager service in the selected AWS region and set "ssl_certificate_arn" property in the config file to the certificate ARN.
 2. Set "arcgis_enterprise_fqdn" property to the ArcGIS Enterprise deployment domain name.
-3. Commit the changes to a Git branch and push the branch to GitHub.
-4. Run enterprise-k8s-aws-ingress workflow using the branch.
-5. Retrieve the DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the ArcGIS Enterprise domain name.
+3. If Route53 DNS is used, set "hosted_zone_id" property to the Route 53 hosted zone ID of the ArcGIS Enterprise domain name.
+4. Commit the changes to a Git branch and push the branch to GitHub.
+5. Run enterprise-k8s-aws-ingress workflow using the branch.
+6. If "hosted_zone_id" property was not specified, retrieve DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the ArcGIS Enterprise domain name.
 
 > The value of "deployment_id" property defines the deployment's Kubernetes namespace.
 

--- a/aws/arcgis-enterprise-k8s/ingress/README.md
+++ b/aws/arcgis-enterprise-k8s/ingress/README.md
@@ -7,6 +7,9 @@ a cluster-level ingress controller that routes traffic to the deployment.
 
 See: https://enterprise-k8s.arcgis.com/en/latest/deploy/use-a-cluster-level-ingress-controller-with-eks.htm
 
+If a Route 53 hosted zone ID is provided, a CNAME record is created in the hosted zone
+that points the deployment's FQDN to the load balancer's DNS name.
+
 ## Requirements
 
 On the machine where Terraform is executed:
@@ -19,12 +22,14 @@ On the machine where Terraform is executed:
 
 | Name | Version |
 |------|---------|
+| aws | ~> 5.22 |
 | kubernetes | ~> 2.26 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_route53_record.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [kubernetes_ingress_v1.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) | resource |
 | [kubernetes_namespace.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 
@@ -35,6 +40,7 @@ On the machine where Terraform is executed:
 | arcgis_enterprise_context | Context path to be used in the URL for ArcGIS Enterprise on Kubernetes | `string` | `"arcgis"` | no |
 | arcgis_enterprise_fqdn | The fully qualified domain name (FQDN) to access ArcGIS Enterprise on Kubernetes | `string` | n/a | yes |
 | deployment_id | ArcGIS Enterprise deployment Id | `string` | `"arcgis-enterprise-k8s"` | no |
+| hosted_zone_id | The Route 53 hosted zone ID for the domain | `string` | `null` | no |
 | scheme | The scheme for the load balancer. Set to 'internet-facing' for public access. | `string` | `"internet-facing"` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis-enterprise"` | no |
 | ssl_certificate_arn | SSL certificate ARN for HTTPS listeners of the load balancer | `string` | n/a | yes |

--- a/aws/arcgis-enterprise-k8s/ingress/variables.tf
+++ b/aws/arcgis-enterprise-k8s/ingress/variables.tf
@@ -67,3 +67,14 @@ variable "arcgis_enterprise_context" {
     error_message = "The arcgis_enterprise_context value must be an alphanumeric string."
   }
 }
+
+variable "hosted_zone_id" {
+  description = "The Route 53 hosted zone ID for the domain"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = can(regex("^Z[0-9A-Z]{14,}$", var.hosted_zone_id)) || var.hosted_zone_id == null
+    error_message = "The hosted_zone_id value must be a valid Route 53 hosted zone ID."
+  }
+}

--- a/aws/iam-policies/ArcGISEnterpriseK8s.json
+++ b/aws/iam-policies/ArcGISEnterpriseK8s.json
@@ -25,7 +25,16 @@
                 "eks:DescribeCluster"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets",
+                "route53:GetChange",
+                "route53:GetHostedZone",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": "*"
         }
-
     ]
 }

--- a/config/aws/arcgis-enterprise-k8s/ingress.tfvars.json
+++ b/config/aws/arcgis-enterprise-k8s/ingress.tfvars.json
@@ -2,6 +2,7 @@
   "arcgis_enterprise_context": "arcgis",   
   "arcgis_enterprise_fqdn": "<arcgis_enterprise_fqdn>",
   "deployment_id": "arcgis-enterprise-k8s",
+  "hosted_zone_id": null,
   "scheme": "internet-facing",
   "site_id": "arcgis-enterprise",
   "ssl_certificate_arn": "<ssl_certificate_arn>",


### PR DESCRIPTION
If "hosted_zone_id" property is set in ingress.tfvars.json, enterprise-k8s-aws-ingress workflow now creates a CNAME record for the domain specified by "arcgis_enterprise_fqdn" property that points to the ingress ALB DNS name.