### PR TITLE
#78 Support server federation with Enterprise on K8s

### DIFF
--- a/ansible_collections/arcgis/portal/playbooks/federate_server.yaml
+++ b/ansible_collections/arcgis/portal/playbooks/federate_server.yaml
@@ -10,6 +10,7 @@
       no_log: false
       arcgis.portal.federate_server:
         portal_url: '{{ portal_url }}'
+        portal_org_id: '{{ portal_org_id }}'
         username: '{{ username }}'
         password: '{{ password }}'
         server_url: '{{ server_url }}'

--- a/ansible_collections/arcgis/portal/plugins/modules/federate_server.py
+++ b/ansible_collections/arcgis/portal/plugins/modules/federate_server.py
@@ -14,6 +14,10 @@ version_added: "0.1.0"
 description: This module federates an ArcGIS Server with Portal for ArGIS in a specific role and function.
 
 options:
+    portal_org_id:
+        description: ArcGIS Enterprise organization Id.
+        required: false
+        type: str
     portal_url:
         description: URL of the Portal for ArcGIS.
         required: true
@@ -23,7 +27,7 @@ options:
         required: true
         type: str
     password:
-        description: Portal for ArcGIS administrative account pasword.
+        description: Portal for ArcGIS administrative account password.
         required: true
         type: str
     server_url:
@@ -39,7 +43,7 @@ options:
         required: true
         type: str
     server_password:
-        description: ArcGIS Server administrative account pasword.
+        description: ArcGIS Server administrative account password.
         required: true
         type: str
     server_role:
@@ -57,6 +61,7 @@ options:
 EXAMPLES = r'''
 - name: Federate ArcGIS Server with Portal for ArcGIS as Raster Analytics server
   arcgis.portal.federate_server:
+    portal_org_id: 0123456789ABCDEF
     portal_url: https://portal.domain.com:7443/arcgis
     username: portaladmin
     password: <portal password>
@@ -77,12 +82,13 @@ RETURN = r'''
 
 import os
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.arcgis.portal.plugins.module_utils.portal_admin_client import PortalAdminClient
+from ansible_collections.arcgis.portal.plugins.module_utils.org_admin_client import OrgAdminClient
 
 
 def run_module():
     module_args = dict(
         portal_url=dict(type='str', required=True),
+        portal_org_id=dict(type='str', required=False, default=None),    
         username=dict(type='str', required=True),
         password=dict(type='str', required=True),
         server_url=dict(type='str', required=True),
@@ -106,9 +112,10 @@ def run_module():
     if module.check_mode:
         module.exit_json(**result)
     
-    admin = PortalAdminClient(module.params['portal_url'], 
+    admin = OrgAdminClient(module.params['portal_url'], 
                               module.params['username'], 
-                              module.params['password'])
+                              module.params['password'],
+                              module.params['portal_org_id'])
     
     try:
         # admin.wait_until_available()

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -89,7 +89,7 @@ Instructions:
 1. Add ArcGIS Server authorization file for the ArcGIS Server version to `config/authorization/<ArcGIS version>` directory of the repository and set "server_authorization_file_path" property in application.tfvars.json file to the file paths.
 2. Set "deployment_fqdn" property in application.tfvars.json file to the ArcGIS Server deployment fully qualified domain name.
 3. Set "admin_username", "admin_password", and "admin_email" in application.tfvars.json file to the ArcGIS Server administrator account properties.
-4. If the ArcGIS Server needs to be federated with Portal for ArcGIS, set "server_role" and "server_functions" properties in application.tfvars.json file to the required server role and function and "portal_url", "portal_username", and "portal_password" properties to the Portal for ArcGIS URL and administrator account properties.
+4. If the ArcGIS Server needs to be federated with Portal for ArcGIS, set "server_role" and "server_functions" properties in application.tfvars.json file to the required server role and function and "portal_url", "portal_username", and "portal_password" properties to the Portal for ArcGIS URL and administrator account properties. To federate the server with ArcGIS Enterprise on Kubernetes organization, set "portal_org_id" property to "0123456789ABCDEF", which is the default organization Id.
 5. Commit the changes to the Git branch and push the branch to GitHub.
 6. Run server-linux-aws-application workflow using the branch.
 

--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -92,10 +92,10 @@ The module uses the following SSM parameters:
 | is_upgrade | Flag to indicate if this is an upgrade deployment | `bool` | `false` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
 | os | Operating system id (rhel8\|rhel9) | `string` | `"rhel8"` | no |
+| portal_org_id | ArcGIS Enterprise organization Id | `string` | `null` | no |
 | portal_password | Portal for ArcGIS user password | `string` | `null` | no |
 | portal_url | Portal for ArcGIS URL | `string` | `null` | no |
 | portal_username | Portal for ArcGIS user name | `string` | `null` | no |
-| root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server | `string` | `null` | no |
 | run_as_user | User name for the account used to run ArcGIS Server. | `string` | `"arcgis"` | no |
 | server_authorization_file_path | Local path of ArcGIS Server authorization file | `string` | n/a | yes |
 | server_functions | Functions of the federated server | `list(string)` | `[]` | no |

--- a/aws/arcgis-server-linux/application/main.tf
+++ b/aws/arcgis-server-linux/application/main.tf
@@ -274,6 +274,7 @@ module "arcgis_server_federation" {
   machine_roles = ["primary"]
   playbook = "arcgis.portal.federate_server"
   external_vars = {
+    portal_org_id = var.portal_org_id
     portal_url = var.portal_url
     username = var.portal_username
     password = var.portal_password

--- a/aws/arcgis-server-linux/application/variables.tf
+++ b/aws/arcgis-server-linux/application/variables.tf
@@ -115,6 +115,12 @@ variable "os" {
   }
 }
 
+variable "portal_org_id" {
+  description = "ArcGIS Enterprise organization Id"
+  type        = string
+  default     = null
+}
+
 variable "portal_password" {
   description = "Portal for ArcGIS user password"
   type        = string

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
@@ -40,7 +40,7 @@ jobs:
       id: install-boto3
       run: |
         pip install boto3
-        pip install ansible
+        pip install ansible-core==2.16.7 ansible==9.6.0
     - name: Install Ansible Collections
       id: install-collections
       run: ansible-galaxy collection install ${{ github.workspace }}/ansible_collections/arcgis -p /usr/share/ansible/collections

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-backup.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-backup.yaml
@@ -34,7 +34,7 @@ jobs:
       id: install-boto3
       run: |
         pip install boto3
-        pip install ansible
+        pip install ansible-core==2.16.7 ansible==9.6.0
     - name: Install Ansible Collections
       id: install-collections
       run: ansible-galaxy collection install ${{ github.workspace }}/ansible_collections/arcgis -p /usr/share/ansible/collections

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-image.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-image.yaml
@@ -32,7 +32,7 @@ jobs:
         id: install-boto3
         run: |
           pip install boto3
-          pip install ansible
+          pip install ansible-core==2.16.7 ansible==9.6.0
       - name: Install Ansible Collections
         id: install-collections
         run: ansible-galaxy collection install ${{ github.workspace }}/ansible_collections/arcgis -p /usr/share/ansible/collections

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-restore.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-restore.yaml
@@ -32,7 +32,7 @@ jobs:
       id: install-boto3
       run: |
         pip install boto3
-        pip install ansible
+        pip install ansible-core==2.16.7 ansible==9.6.0
     - name: Install Ansible Collections
       id: install-collections
       run: ansible-galaxy collection install ${{ github.workspace }}/ansible_collections/arcgis -p /usr/share/ansible/collections

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -13,6 +13,7 @@
   "log_level": "WARNING",
   "os": "rhel8",
   "portal_password": null,
+  "portal_org_id": null,
   "portal_url": null,
   "portal_username": null,
   "run_as_user": "arcgis",


### PR DESCRIPTION
To federate the server with ArcGIS Enterprise on Kubernetes organization, set "portal_org_id" property in application.tfvars.json to "0123456789ABCDEF" (the default organization Id).