### PR TITLE
#75 Optimized enterprise-k8s-aws-image workflow

### DIFF
--- a/aws/arcgis-enterprise-k8s/image/copy-docker-hub-images.sh
+++ b/aws/arcgis-enterprise-k8s/image/copy-docker-hub-images.sh
@@ -13,6 +13,7 @@
 set -e
 
 MANIFEST_PATH=$1
+ARCGIS_VERSION=$2
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 ECR_REGISTRY_URL=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
 
@@ -21,7 +22,7 @@ echo $CONTAINER_REGISTRY_PASSWORD | docker login --username $CONTAINER_REGISTRY_
 aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY_URL
 
 # Get the list of images from the version manifest file
-full_cmd="cat $MANIFEST_PATH | jq -r '.versions[] | .containers[].image' | sort | uniq"
+full_cmd="cat $MANIFEST_PATH | jq -r '.versions[] | select(.version==\"$ARCGIS_VERSION\") | .containers[].image' | sort | uniq"
 IMAGE_LIST=$(eval $full_cmd)
 num=$(echo $IMAGE_LIST | wc -w)
 

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-image.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-image.yaml
@@ -49,7 +49,7 @@ jobs:
             echo "ECR repository prefix: $ECR_REPOSITORY_PREFIX"
             MANIFEST_PATH=./manifests/$ARCGIS_VERSION.dat
             chmod +x ./copy-docker-hub-images.sh
-            ./copy-docker-hub-images.sh $MANIFEST_PATH
+            ./copy-docker-hub-images.sh $MANIFEST_PATH $ARCGIS_VERSION
           fi
       - name: Build Admin CLI Image
         run: |


### PR DESCRIPTION
enterprise-k8s-aws-image workflow now only copies to ECR images belonging to specific ArcGIS Enterprise version.