### PR TITLE
#87 Support changing admin_password in enterprise-k8s-aws-organization workflow

### DIFF
--- a/aws/arcgis-enterprise-k8s/organization/main.tf
+++ b/aws/arcgis-enterprise-k8s/organization/main.tf
@@ -152,13 +152,8 @@ resource "kubernetes_pod" "enterprise_admin_cli" {
         }
       }
       env {
-        name = "ARCGIS_ENTERPRISE_PASSWORD"
-        value_from {
-          secret_key_ref {
-            name = kubernetes_secret.admin_cli_credentials.metadata[0].name
-            key  = "password"
-          }
-        }
+        name = "ARCGIS_ENTERPRISE_PASSWORD_FILE"
+        value = "/var/run/secrets/admin-cli-credentials/password"
       }
       resources {
         limits = {
@@ -173,6 +168,17 @@ resource "kubernetes_pod" "enterprise_admin_cli" {
       command = [
         "sleep", "infinity"
       ]
+      volume_mount {
+        name       = "admin-cli-credentials"
+        read_only  = true
+        mount_path = "/var/run/secrets/admin-cli-credentials"
+      }
+    }
+    volume {
+      name = "admin-cli-credentials"
+      secret {
+        secret_name = kubernetes_secret.admin_cli_credentials.metadata[0].name
+      }
     }
     restart_policy = "Always"
   }

--- a/aws/arcgis-enterprise-k8s/organization/variables.tf
+++ b/aws/arcgis-enterprise-k8s/organization/variables.tf
@@ -137,12 +137,32 @@ variable "admin_username" {
   description = "ArcGIS Enterprise on Kubernetes organization administrator account username"
   type        = string
   default     = "siteadmin"
+
+  validation {
+    condition     = can(regex("^[-a-zA-Z0-9@_.]{6,}$", var.admin_username))
+    error_message = "The admin_username value must be at least six characters in length. The only special characters allowed are the at sign (@), dash (-), dot (.), and underscore (_)."
+  }
 }
 
 variable "admin_password" {
   description = "ArcGIS Enterprise on Kubernetes organization administrator account password"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(var.admin_password) >= 8
+    error_message = "The admin_password value must be at least eight characters in length."
+  }
+
+  validation {
+    condition     = can(regex("[A-Za-z]", var.admin_password))
+    error_message = "The admin_password value must contain at least one alphabet letter (uppercase or lowercase)."
+  }
+
+  validation {
+    condition     = can(regex("\\d", var.admin_password))
+    error_message = "The admin_password value must contain at least one digit."
+  }
 }
 
 variable "admin_email" {
@@ -225,7 +245,7 @@ variable "backup_job_timeout" {
 variable "enterprise_admin_cli_version" {
   description = "ArcGIS Enterprise Admin CLI image tag"
   type        = string
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "storage" {

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-organization.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-organization.yaml
@@ -59,14 +59,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
           ADMIN_CLI_VERSION=$(jq -r '.version' $ADMIN_CLI_METADATA_FILE)
-          IS_UPGRADE=1
-          helm status arcgis --namespace=$DEPLOYMENT_ID > /dev/null || IS_UPGRADE=0
-          echo "is-upgrade=$IS_UPGRADE" >> "$GITHUB_OUTPUT"
-          if [ $IS_UPGRADE -eq 1 ]; then
-            UPGRADE_TOKEN=$(kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis generate-token --expiration $MAX_UPGRADE_TIME)
-          else
-            UPGRADE_TOKEN="token"
-          fi
+          UPGRADE_TOKEN=$(kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis generate-token --expiration $MAX_UPGRADE_TIME) || UPGRADE_TOKEN="token"
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/organization.tfstate" -backend-config="region=$AWS_DEFAULT_REGION" 
           terraform apply -var-file=$CONFIG_FILE -var "upgrade_token=$UPGRADE_TOKEN" -var "enterprise_admin_cli_version=$ADMIN_CLI_VERSION" -auto-approve 
       - name: Retrieve Logs

--- a/enterprise-admin-cli/commands/cli_utils.py
+++ b/enterprise-admin-cli/commands/cli_utils.py
@@ -23,6 +23,7 @@ def create_argument_parser(prog, description) -> argparse.ArgumentParser:
     parser.add_argument('--url', dest='url', required=False, help='ArcGIS Enterprise URL')
     parser.add_argument('-u', '--user', dest='user', required=False, help='ArcGIS Enterprise user name')
     parser.add_argument('-p', '--password', dest='password', required=False, help='ArcGIS Enterprise user password')
+    parser.add_argument('--password-file', dest='password_file', required=False, help='ArcGIS Enterprise user password file path')
 
     return parser
 
@@ -45,11 +46,19 @@ def create_admin_client(args: Sequence[str]) -> EnterpriseAdminClient:
     else:
         raise ValueError('ArcGIS Enterprise user name is not provided.')
     
+    if args.password_file:
+        with open(args.password_file, 'r') as file:
+            password = file.read()
+    elif 'ARCGIS_ENTERPRISE_PASSWORD_FILE' in os.environ:
+        with open(os.environ['ARCGIS_ENTERPRISE_PASSWORD_FILE'], 'r') as file:
+            password = file.read()
+
     if args.password:
         password = args.password
     elif 'ARCGIS_ENTERPRISE_PASSWORD' in os.environ:
         password = os.environ['ARCGIS_ENTERPRISE_PASSWORD']
-    else:     
-        raise ValueError('ArcGIS Enterprise user password is not provided.')
+    
+    if not password:
+        raise ValueError('ArcGIS Enterprise user password is not specified.')
     
     return EnterpriseAdminClient(url, user, password)

--- a/enterprise-admin-cli/metadata.json
+++ b/enterprise-admin-cli/metadata.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.0",
+    "version": "0.2.0",
     "arcgis_python_api_version": "2.3.0",
     "arcgis_rest_api_version": "11.1"
 }

--- a/enterprise-admin-cli/scripts/cli_utils.py
+++ b/enterprise-admin-cli/scripts/cli_utils.py
@@ -30,6 +30,7 @@ def create_argument_parser(prog, description) -> argparse.ArgumentParser:
     parser.add_argument('--url', dest='url', required=False, help='ArcGIS Enterprise URL')
     parser.add_argument('-u', '--user', dest='user', required=False, help='ArcGIS Enterprise user name')
     parser.add_argument('-p', '--password', dest='password', required=False, help='ArcGIS Enterprise user password')
+    parser.add_argument('--password-file', dest='password_file', required=False, help='ArcGIS Enterprise user password file path')    
 
     return parser
 
@@ -49,13 +50,21 @@ def create_gis_client(args: Sequence[str]) -> GIS:
     else:
         raise ValueError('ArcGIS Enterprise user name is not provided.')
     
+    if args.password_file:
+        with open(args.password_file, 'r') as file:
+            password = file.read()
+    elif 'ARCGIS_ENTERPRISE_PASSWORD_FILE' in os.environ:
+        with open(os.environ['ARCGIS_ENTERPRISE_PASSWORD_FILE'], 'r') as file:
+            password = file.read()    
+    
     if args.password:
         password = args.password
     elif 'ARCGIS_ENTERPRISE_PASSWORD' in os.environ:
         password = os.environ['ARCGIS_ENTERPRISE_PASSWORD']
-    else:     
-        raise ValueError('ArcGIS Enterprise user password is not provided.')
-    
+
+    if not password:
+        raise ValueError('ArcGIS Enterprise user password is not specified.')
+
     wait_for_portal(url)
 
     return GIS(url=url, username=user, password=password)


### PR DESCRIPTION
To gracefully handle admin_password changes, the PR:

 * Validates that admin_password input variable in archis-enterprise-k8s/organization terraform module meets the password complexity requirements.
* Uses more reliable check to test if enterprise-k8s-aws-organization workflow run is an upgrade.
* Mounts admin-cli-credentials secret to enterprise-admin-cli pod and makes the CLI commands use password specified in a file in the mounted directory. 