### PR TITLE
#90 Support setting server authorization options

### DIFF
--- a/ansible_collections/arcgis/server/playbooks/node.yaml
+++ b/ansible_collections/arcgis/server/playbooks/node.yaml
@@ -25,18 +25,15 @@
     root_cert_alias: ''
     keystore_file: ''
     keystore_password: ''
-    cert_alias: ''    
+    cert_alias: ''
+    authorization_options: ''
   tasks:
     - name: Authorize ArcGIS Server
       become: true
       become_user: '{{ run_as_user }}'
       vars:
         ansible_aws_ssm_timeout: 600
-      ansible.builtin.command:
-        argv:
-          - '{{ install_dir }}/arcgis/server/tools/authorizeSoftware'
-          - -f
-          - '{{ authorization_file }}'
+      ansible.builtin.command: '{{ install_dir }}/arcgis/server/tools/authorizeSoftware -f {{ authorization_file }} {{ authorization_options }}'
       register: authorize_software
       changed_when: authorize_software.rc == 0
     - name: Start arcgisserver service

--- a/ansible_collections/arcgis/server/playbooks/primary.yaml
+++ b/ansible_collections/arcgis/server/playbooks/primary.yaml
@@ -29,17 +29,14 @@
     keystore_file: ''
     keystore_password: ''
     cert_alias: ''
+    authorization_options: ''
   tasks:
     - name: Authorize ArcGIS Server
       become: true
       become_user: '{{ run_as_user }}'
       vars:
         ansible_aws_ssm_timeout: 600
-      ansible.builtin.command:
-        argv:
-          - '{{ install_dir }}/arcgis/server/tools/authorizeSoftware'
-          - -f
-          - '{{ authorization_file }}'
+      ansible.builtin.command: '{{ install_dir }}/arcgis/server/tools/authorizeSoftware -f {{ authorization_file }} {{ authorization_options }}'
       register: authorize_software
       changed_when: authorize_software.rc == 0
     - name: Start arcgisserver service

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -132,6 +132,7 @@ The module uses the following SSM parameters:
 | security_question | Primary ArcGIS Enterprise administrator security question | `string` | `"What city were you born in?"` | no |
 | security_question_answer | Primary ArcGIS Enterprise administrator security question answer | `string` | n/a | yes |
 | server_authorization_file_path | Local path of ArcGIS Server authorization file | `string` | n/a | yes |
+| server_authorization_options | Additional ArcGIS Server software authorization command line options | `string` | `""` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis-enterprise"` | no |
 | tomcat_version | Apache Tomcat version | `string` | `"9.0.48"` | no |
 

--- a/aws/arcgis-enterprise-base-linux/application/main.tf
+++ b/aws/arcgis-enterprise-base-linux/application/main.tf
@@ -601,6 +601,7 @@ module "arcgis_enterprise_primary" {
         admin_username                 = var.admin_username
         admin_password                 = var.admin_password
         authorization_file             = "${local.authorization_files_dir}/${basename(var.server_authorization_file_path)}"
+        authorization_options          = var.server_authorization_options
         keystore_file                  = local.keystore_file
         keystore_password              = var.keystore_file_password
         root_cert                      = local.root_cert
@@ -733,6 +734,7 @@ module "arcgis_enterprise_standby" {
         admin_password              = var.admin_password
         log_dir                     = "/opt/arcgis/server/usr/logs"
         authorization_file          = "${local.authorization_files_dir}/${basename(var.server_authorization_file_path)}"
+        authorization_options       = var.server_authorization_options
         keystore_file               = local.keystore_file
         keystore_password           = var.keystore_file_password
         root_cert                   = local.root_cert

--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -95,6 +95,13 @@ variable "server_authorization_file_path" {
   type        = string
 }
 
+variable "server_authorization_options" {
+  description = "Additional ArcGIS Server software authorization command line options"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "portal_authorization_file_path" {
   description = "Local path of Portal for ArcGIS authorization file"
   type        = string

--- a/aws/arcgis-enterprise-base-windows/application/README.md
+++ b/aws/arcgis-enterprise-base-windows/application/README.md
@@ -133,6 +133,7 @@ The module uses the following SSM parameters:
 | security_question | Primary ArcGIS Enterprise administrator security question | `string` | `"What city were you born in?"` | no |
 | security_question_answer | Primary ArcGIS Enterprise administrator security question answer | `string` | n/a | yes |
 | server_authorization_file_path | Local path of ArcGIS Server authorization file | `string` | n/a | yes |
+| server_authorization_options | Additional ArcGIS Server software authorization command line options | `string` | `""` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis-enterprise"` | no |
 
 ## Outputs

--- a/aws/arcgis-enterprise-base-windows/application/main.tf
+++ b/aws/arcgis-enterprise-base-windows/application/main.tf
@@ -607,6 +607,7 @@ module "arcgis_enterprise_primary" {
         admin_username                 = var.admin_username
         admin_password                 = var.admin_password
         authorization_file             = "${local.authorization_files_dir}\\${basename(var.server_authorization_file_path)}"
+        authorization_options          = var.server_authorization_options
         keystore_file                  = var.keystore_file_path != null ? local.keystore_file : ""
         keystore_password              = var.keystore_file_password
         root_cert                      = local.root_cert
@@ -748,6 +749,7 @@ module "arcgis_enterprise_standby" {
         admin_username              = var.admin_username
         admin_password              = var.admin_password
         authorization_file          = "${local.authorization_files_dir}\\${basename(var.server_authorization_file_path)}"
+        authorization_options       = var.server_authorization_options
         keystore_file               = var.keystore_file_path != null ? local.keystore_file : ""
         keystore_password           = var.keystore_file_password
         root_cert                   = local.root_cert

--- a/aws/arcgis-enterprise-base-windows/application/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/application/variables.tf
@@ -84,6 +84,13 @@ variable "server_authorization_file_path" {
   type        = string
 }
 
+variable "server_authorization_options" {
+  description = "Additional ArcGIS Server software authorization command line options"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "portal_authorization_file_path" {
   description = "Local path of Portal for ArcGIS authorization file"
   type        = string

--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -117,6 +117,7 @@ The module uses the following SSM parameters:
 | root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server | `string` | `null` | no |
 | run_as_user | User name for the account used to run ArcGIS Server. | `string` | `"arcgis"` | no |
 | server_authorization_file_path | Local path of ArcGIS Server authorization file | `string` | n/a | yes |
+| server_authorization_options | Additional ArcGIS Server software authorization command line options | `string` | `""` | no |
 | server_functions | Functions of the federated server | `list(string)` | `[]` | no |
 | server_role | ArcGIS Server role | `string` | `""` | no |
 | services_dir_enabled | Enable REST handler services directory | `bool` | `true` | no |

--- a/aws/arcgis-server-linux/application/main.tf
+++ b/aws/arcgis-server-linux/application/main.tf
@@ -276,6 +276,7 @@ module "arcgis_server_primary" {
   external_vars = {
     install_dir        = "/opt"
     authorization_file = "${local.authorization_files_dir}/${basename(var.server_authorization_file_path)}"
+    authorization_options = var.server_authorization_options
     admin_username     = var.admin_username
     admin_password     = var.admin_password
     directories_root   = "${local.mount_point}/gisdata/arcgisserver"
@@ -311,6 +312,7 @@ module "arcgis_server_node" {
   external_vars = {
     install_dir        = "/opt"
     authorization_file = "${local.authorization_files_dir}/${basename(var.server_authorization_file_path)}"
+    authorization_options = var.server_authorization_options
     admin_username     = var.admin_username
     admin_password     = var.admin_password
     primary_server_url = "https://${local.primary_hostname}:6443/arcgis"

--- a/aws/arcgis-server-linux/application/variables.tf
+++ b/aws/arcgis-server-linux/application/variables.tf
@@ -165,6 +165,13 @@ variable "server_authorization_file_path" {
   type        = string
 }
 
+variable "server_authorization_options" {
+  description = "Additional ArcGIS Server software authorization command line options"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "server_functions" {
   description = "Functions of the federated server"
   type        = list(string)

--- a/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
@@ -27,6 +27,7 @@
   "security_question": "What city were you born in?",
   "security_question_answer": "<security_question_answer>",
   "server_authorization_file_path": "~/config/authorization/11.3/server_113.prvc",
+  "server_authorization_options": "",
   "site_id": "arcgis-enterprise",
   "tomcat_version": "9.0.48"
 }

--- a/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
@@ -27,5 +27,6 @@
   "security_question_answer": "<security_question_answer>",
   "security_question": "What city were you born in?",
   "server_authorization_file_path": "~/config/authorization/11.3/server_113.prvc",
+  "server_authorization_options": "",
   "site_id": "arcgis-enterprise"
 }

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -18,6 +18,7 @@
   "portal_username": null,
   "run_as_user": "arcgis",
   "server_authorization_file_path": "~/config/authorization/11.3/server_113.prvc",
+  "server_authorization_options": "",
   "server_functions": [],
   "server_role": "",
   "services_dir_enabled": true,


### PR DESCRIPTION
This PR adds "server_authorization_options" input variable to enterprise-base-linux-aws-application, enterprise-base-windows-aws-application, and server-linux-aws-application workflows. Value of  "server_authorization_options" is added at the end of ArcGIS Server's software authorization command line. 