### PR TITLE
#91 Register new backup stores on k8s org upgrades

### DIFF
--- a/aws/arcgis-enterprise-k8s/organization/variables.tf
+++ b/aws/arcgis-enterprise-k8s/organization/variables.tf
@@ -163,6 +163,11 @@ variable "admin_password" {
     condition     = can(regex("\\d", var.admin_password))
     error_message = "The admin_password value must contain at least one digit."
   }
+
+  validation {
+    condition     = can(regex("[^A-Za-z0-9]", var.admin_password))
+    error_message = "The admin_password value must contain at least one special character."
+  }
 }
 
 variable "admin_email" {

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-backup.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-backup.yaml
@@ -46,5 +46,6 @@ jobs:
         PASSCODE=$(jq -r '.passcode' $CONFIG_FILE)
         RETENTION=$(jq -r '.retention' $CONFIG_FILE)
         DESCRIPTION=$(jq -r '.description' $CONFIG_FILE)
+        [[ "$STORE" == "null" || "$STORE" == "" ]] && STORE_ARG="" || STORE_ARG="--store $STORE"
         aws eks update-kubeconfig --region $AWS_DEFAULT_REGION --name $SITE_ID
-        kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis create-backup --store "$STORE" --backup "$BACKUP" --passcode "$PASSCODE" --description "$DESCRIPTION" --retention $RETENTION --wait
+        kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis create-backup $STORE_ARG --backup "$BACKUP" --passcode "$PASSCODE" --description "$DESCRIPTION" --retention $RETENTION --wait

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-restore.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-restore.yaml
@@ -43,10 +43,7 @@ jobs:
         PASSCODE=$(jq -r '.passcode' $CONFIG_FILE)
         BACKUP=$(jq -r '.backup' $CONFIG_FILE)
         TIMEOUT=$(jq -r '.timeout' $CONFIG_FILE)
-        if [ "$BACKUP" == "null" ] || [ "$BACKUP" == "" ]; then
-          BACKUP_ARG=""
-        else
-          BACKUP_ARG="--backup $BACKUP"
-        fi 
+        [[ "$STORE" == "null" || "$STORE" == "" ]] && STORE_ARG="" || STORE_ARG="--store $STORE"
+        [[ "$BACKUP" == "null" || "$BACKUP" == "" ]] && BACKUP_ARG="" || BACKUP_ARG="--backup $BACKUP"
         aws eks update-kubeconfig --region $AWS_DEFAULT_REGION --name $SITE_ID
-        kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis restore-organization --store "$STORE" $BACKUP_ARG --passcode "$PASSCODE" --wait --timeout $TIMEOUT
+        kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis restore-organization $STORE_ARG $BACKUP_ARG --passcode "$PASSCODE" --wait --timeout $TIMEOUT

--- a/config/aws/arcgis-enterprise-k8s/backup.vars.json
+++ b/config/aws/arcgis-enterprise-k8s/backup.vars.json
@@ -5,5 +5,5 @@
     "prefix": "enterprise-k8s-aws-backup",
     "retention": -1,
     "site_id": "arcgis-enterprise",
-    "store": "s3-backup-store"
+    "store": null
 }

--- a/config/aws/arcgis-enterprise-k8s/restore.vars.json
+++ b/config/aws/arcgis-enterprise-k8s/restore.vars.json
@@ -3,6 +3,6 @@
     "deployment_id": "arcgis-enterprise-k8s",
     "passcode": "<passcode>",
     "site_id": "arcgis-enterprise",
-    "store": "s3-backup-store",
+    "store": null,
     "timeout": 14400
 }


### PR DESCRIPTION
This PR:
1. Makes enterprise-k8s-aws-organization workflow to register new S3 backup store on upgrades.
2. Adds version number to the backup store root directory.
3. Makes enterprise-k8s-aws-backup and enterprise-k8s-aws-restore workflows use default backup store if "store" input variable is set to `null`.
4. Adds "The admin_password value must contain at least one special character." requirement validation in enterprise-k8s-aws-organization workflow.