### PR TITLE
#115 Removed arcgis_online_username/arcgis_online_password config pros

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "ansible.python.interpreterPath": "c:\\Program Files\\Python311\\python.exe"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ansible.python.interpreterPath": "c:\\Program Files\\Python311\\python.exe"
+}

--- a/ansible_collections/arcgis/common/playbooks/s3_files.yaml
+++ b/ansible_collections/arcgis/common/playbooks/s3_files.yaml
@@ -17,7 +17,7 @@
 # In the directory it creates a manifest file from the provided template,
 # replacing the S3 bucket name, region, and local repository path with the
 # provided values. Then it uses arcgis.common.s3files module to download
-# ArcGIS Server setups and patches from the S3 bucket to the local repository.
+# setups and patches from the S3 bucket to the local repository.
 
 - name: Download files from S3 bucket to local directories
   hosts: all

--- a/ansible_collections/arcgis/common/plugins/modules/s3files.py
+++ b/ansible_collections/arcgis/common/plugins/modules/s3files.py
@@ -22,7 +22,7 @@ DOCUMENTATION = r'''
 ---
 module: s3files
 
-short_description: Dowloads files from S3 bucket to local directories
+short_description: Downloads files from S3 bucket to local directories
 
 version_added: "0.1.0"
 
@@ -41,7 +41,7 @@ options:
 
 EXAMPLES = r'''
 - name: Download setups from private S3 repository
-  s3files:
+  arcgis.common.s3files:
     manifest: '/opt/software/arcgis-server-s3files-11.2.json'
 '''
 

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -110,8 +110,6 @@ The module uses the following SSM parameters:
 | admin_password | Primary ArcGIS Enterprise administrator user password | `string` | n/a | yes |
 | admin_username | Primary ArcGIS Enterprise administrator user name | `string` | `"siteadmin"` | no |
 | arcgis_data_store_patches | File names of ArcGIS Data Store patches to install. | `list(string)` | `[]` | no |
-| arcgis_online_password | ArcGIS Online user password | `string` | `null` | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | `null` | no |
 | arcgis_portal_patches | File names of Portal for ArcGIS patches to install. | `list(string)` | `[]` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install. | `list(string)` | `[]` | no |
 | arcgis_version | ArcGIS Enterprise version | `string` | `"11.3"` | no |

--- a/aws/arcgis-enterprise-base-linux/application/main.tf
+++ b/aws/arcgis-enterprise-base-linux/application/main.tf
@@ -212,8 +212,6 @@ module "s3_copy_files" {
   source                 = "../../modules/s3_copy_files"
   bucket_name            = nonsensitive(data.aws_ssm_parameter.s3_repository.value)
   index_file             = local.index_file_path
-  arcgis_online_username = var.arcgis_online_username
-  arcgis_online_password = var.arcgis_online_password
 }
 
 # Install Chef Client and Chef Cookbooks for ArcGIS on all EC2 instances of the deployment

--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -238,19 +238,6 @@ variable "arcgis_web_adaptor_patches" {
   default     = []
 }
 
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type        = string
-  default     = null
-}
-
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type        = string
-  sensitive   = true
-  default     = null
-}
-
 variable "config_store_type" {
   description = "ArcGIS Server configuration store type"
   type        = string

--- a/aws/arcgis-enterprise-base-linux/image/README.md
+++ b/aws/arcgis-enterprise-base-linux/image/README.md
@@ -50,8 +50,6 @@ The template uses the following SSM parameters:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | arcgis_data_store_patches |File names of ArcGIS Data Store patches to install | `string` | `[]` | no |
-| arcgis_online_password | ArcGIS Online user password | `string` | null | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | null | no |
 | arcgis_portal_patches | File names of Portal for ArcGIS patches to install | `string` | `[]` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install | `string` | `[]` | no |
 | arcgis_version | ArcGIS Enterprise version | `string` | `"11.3"` | no |

--- a/aws/arcgis-enterprise-base-linux/image/main.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/main.pkr.hcl
@@ -177,7 +177,7 @@ build {
 
   # Copy files to private S3 repository
   provisioner "shell-local" {
-    command = "python -m s3_copy_files -f ${local.s3_files_json_path} -u ${var.arcgis_online_username} -p ${var.arcgis_online_password} -b ${data.amazon-parameterstore.s3_repository.value}"
+    command = "python -m s3_copy_files -f ${local.s3_files_json_path} -b ${data.amazon-parameterstore.s3_repository.value}"
   }
 
   # Install AWS CLI

--- a/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
@@ -120,16 +120,3 @@ variable "skip_create_ami" {
   type = bool
   default = false
 }
-
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type = string
-  default = null
-}
-
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type = string
-  sensitive = true
-  default = null
-}

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-application.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-application.yaml
@@ -59,7 +59,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$AWS_DEFAULT_REGION"
-        terraform apply -var-file $CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Output
       id: output  
       run: echo arcgis_portal_url=$(terraform output arcgis_portal_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
@@ -53,7 +53,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$AWS_DEFAULT_REGION"
-          terraform destroy -var-file $APPLICATION_CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD -auto-approve
+          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
       - name: Destroy Infrastructure
         id: infrastructure-destroy
         working-directory: aws/arcgis-enterprise-base-linux/infrastructure

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-image.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-image.yaml
@@ -49,4 +49,4 @@ jobs:
         id: packer
         run: |
           packer init .
-          packer build -var-file=$CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD .
+          packer build -var-file=$CONFIG_FILE .

--- a/aws/arcgis-enterprise-base-windows/application/README.md
+++ b/aws/arcgis-enterprise-base-windows/application/README.md
@@ -111,8 +111,6 @@ The module uses the following SSM parameters:
 | admin_password | Primary ArcGIS Enterprise administrator user password | `string` | n/a | yes |
 | admin_username | Primary ArcGIS Enterprise administrator user name | `string` | `"siteadmin"` | no |
 | arcgis_data_store_patches | File names of ArcGIS Data Store patches to install. | `list(string)` | `[]` | no |
-| arcgis_online_password | ArcGIS Online user password | `string` | `null` | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | `null` | no |
 | arcgis_portal_patches | File names of Portal for ArcGIS patches to install. | `list(string)` | `[]` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install. | `list(string)` | `[]` | no |
 | arcgis_version | ArcGIS Enterprise version | `string` | `"11.3"` | no |

--- a/aws/arcgis-enterprise-base-windows/application/main.tf
+++ b/aws/arcgis-enterprise-base-windows/application/main.tf
@@ -215,8 +215,6 @@ module "s3_copy_files" {
   source                 = "../../modules/s3_copy_files"
   bucket_name            = nonsensitive(data.aws_ssm_parameter.s3_repository.value)
   index_file             = local.index_file_path
-  arcgis_online_username = var.arcgis_online_username
-  arcgis_online_password = var.arcgis_online_password
 }
 
 # Install Chef Client and Chef Cookbooks for ArcGIS on all EC2 instances of the deployment

--- a/aws/arcgis-enterprise-base-windows/application/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/application/variables.tf
@@ -227,19 +227,6 @@ variable "arcgis_web_adaptor_patches" {
   default     = []
 }
 
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type        = string
-  default     = null
-}
-
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type        = string
-  sensitive   = true
-  default     = null
-}
-
 variable "config_store_type" {
   description = "ArcGIS Server configuration store type"
   type        = string

--- a/aws/arcgis-enterprise-base-windows/image/README.md
+++ b/aws/arcgis-enterprise-base-windows/image/README.md
@@ -55,8 +55,6 @@ The template uses the following SSM parameters:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | arcgis_data_store_patches |File names of ArcGIS Data Store patches to install | `string` | `[]` | no |
-| arcgis_online_password | ArcGIS Online user password | `string` | null | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | null | no |
 | arcgis_portal_patches | File names of Portal for ArcGIS patches to install | `string` | `[]` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install | `string` | `[]` | no |
 | arcgis_version | ArcGIS Enterprise version | `string` | `"11.3"` | no |

--- a/aws/arcgis-enterprise-base-windows/image/main.pkr.hcl
+++ b/aws/arcgis-enterprise-base-windows/image/main.pkr.hcl
@@ -213,7 +213,7 @@ build {
 
   # Copy files to private S3 repository
   provisioner "shell-local" {
-    command = "python -m s3_copy_files -f ${local.index_file_path} -u ${var.arcgis_online_username} -p ${var.arcgis_online_password} -b ${data.amazon-parameterstore.s3_repository.value}"
+    command = "python -m s3_copy_files -f ${local.index_file_path} -b ${data.amazon-parameterstore.s3_repository.value}"
   }
 
   # Install AWS CLI

--- a/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
@@ -114,14 +114,3 @@ variable "skip_create_ami" {
   type = bool
   default = false
 }
-
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type = string
-}
-
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type = string
-  sensitive = true
-}

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-application.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-application.yaml
@@ -60,7 +60,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$AWS_DEFAULT_REGION"
-        terraform apply -var-file $CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Output
       id: output  
       run: echo arcgis_portal_url=$(terraform output arcgis_portal_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
@@ -53,7 +53,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$AWS_DEFAULT_REGION"
-        terraform destroy -var-file $APPLICATION_CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD -auto-approve
+        terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
     - name: Destroy Infrastructure
       id: infrastructure-destroy
       working-directory: aws/arcgis-enterprise-base-windows/infrastructure

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-image.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-image.yaml
@@ -49,4 +49,4 @@ jobs:
         id: packer
         run: |
           packer init .
-          packer build -var-file=$CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD .
+          packer build -var-file=$CONFIG_FILE .

--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -97,8 +97,6 @@ The module uses the following SSM parameters:
 | admin_email | ArcGIS Server administrator e-mail address | `string` | n/a | yes |
 | admin_password | Primary ArcGIS Server administrator user password | `string` | n/a | yes |
 | admin_username | Primary ArcGIS Server administrator user name | `string` | `"siteadmin"` | no |
-| arcgis_online_password | ArcGIS Online user password | `string` | `null` | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | `null` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install. | `list(string)` | `[]` | no |
 | arcgis_version | ArcGIS Server version | `string` | `"11.3"` | no |
 | config_store_type | ArcGIS Server configuration store type | `string` | `"FILESYSTEM"` | no |

--- a/aws/arcgis-server-linux/application/main.tf
+++ b/aws/arcgis-server-linux/application/main.tf
@@ -141,8 +141,6 @@ module "copy_server_files" {
   source                 = "../../modules/s3_copy_files"
   bucket_name            = nonsensitive(data.aws_ssm_parameter.s3_repository.value)
   index_file             = local.server_manifest_path
-  arcgis_online_username = var.arcgis_online_username
-  arcgis_online_password = var.arcgis_online_password
 }
 
 # Download ArcGIS Server setup archives from the private repository S3 bucket

--- a/aws/arcgis-server-linux/application/variables.tf
+++ b/aws/arcgis-server-linux/application/variables.tf
@@ -39,19 +39,6 @@ variable "admin_username" {
   }
 }
 
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type        = string
-  sensitive   = true
-  default     = null
-}
-
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type        = string
-  default     = null
-}
-
 variable "arcgis_server_patches" {
   description = "File names of ArcGIS Server patches to install."
   type        = list(string)

--- a/aws/arcgis-server-linux/application/webadaptor.tf
+++ b/aws/arcgis-server-linux/application/webadaptor.tf
@@ -12,8 +12,6 @@ module "copy_webadaptor_files" {
   source                 = "../../modules/s3_copy_files"
   bucket_name            = nonsensitive(data.aws_ssm_parameter.s3_repository.value)
   index_file             = local.webadaptor_manifest_path
-  arcgis_online_username = var.arcgis_online_username
-  arcgis_online_password = var.arcgis_online_password
   depends_on = [
     module.arcgis_server_node
   ]

--- a/aws/arcgis-server-linux/image/README.md
+++ b/aws/arcgis-server-linux/image/README.md
@@ -53,8 +53,6 @@ The template uses the following SSM parameters:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| arcgis_online_password | ArcGIS Online user password | `string` | null | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | null | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install | `string` | `[]` | no |
 | arcgis_version | ArcGIS Server version | `string` | `"11.3"` | no |
 | deployment_id | Deployment Id | `string` | `"arcgis-server"` | no |

--- a/aws/arcgis-server-linux/image/main.pkr.hcl
+++ b/aws/arcgis-server-linux/image/main.pkr.hcl
@@ -218,7 +218,7 @@ build {
     inline = [
       "echo '${local.server_vars}' > /tmp/server_vars.yaml",
       "echo '${local.inventory}' > /tmp/inventory.aws_ec2.yaml",
-      "python -m s3_copy_files -f ${local.arcgis_server_s3_files} -u ${var.arcgis_online_username} -p ${var.arcgis_online_password} -b ${data.amazon-parameterstore.s3_repository.value}",      
+      "python -m s3_copy_files -f ${local.arcgis_server_s3_files} -b ${data.amazon-parameterstore.s3_repository.value}",      
       "ansible-playbook arcgis.common.s3_files -i /tmp/inventory.aws_ec2.yaml -e @/tmp/server_vars.yaml",
       "ansible-playbook arcgis.common.system -i /tmp/inventory.aws_ec2.yaml -e @/tmp/server_vars.yaml",
       "ansible-playbook arcgis.server.firewalld -i /tmp/inventory.aws_ec2.yaml -e @/tmp/server_vars.yaml",      
@@ -235,7 +235,7 @@ build {
       "echo '${local.inventory}' > /tmp/inventory.aws_ec2.yaml",
       "JDK_VERSION=$(cat ${local.arcgis_webadaptor_s3_files} | jq -r '.arcgis.repository.files.\"jdk_x64_linux.tar.gz\".version')",
       "TOMCAT_VERSION=$(cat ${local.arcgis_webadaptor_s3_files} | jq -r '.arcgis.repository.files.\"tomcat.tar.gz\".version')",
-      "python -m s3_copy_files -f ${local.arcgis_webadaptor_s3_files} -u ${var.arcgis_online_username} -p ${var.arcgis_online_password} -b ${data.amazon-parameterstore.s3_repository.value}",
+      "python -m s3_copy_files -f ${local.arcgis_webadaptor_s3_files} -b ${data.amazon-parameterstore.s3_repository.value}",
       "ansible-playbook arcgis.common.s3_files -i /tmp/inventory.aws_ec2.yaml -e @/tmp/webadaptor_vars.yaml",
       "ansible-playbook arcgis.webadaptor.openjdk -i /tmp/inventory.aws_ec2.yaml -e @/tmp/webadaptor_vars.yaml -e jdk_version=$JDK_VERSION",
       "ansible-playbook arcgis.webadaptor.tomcat -i /tmp/inventory.aws_ec2.yaml -e @/tmp/webadaptor_vars.yaml -e tomcat_version=$TOMCAT_VERSION",

--- a/aws/arcgis-server-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-server-linux/image/variables.pkr.hcl
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
  
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type = string
-  sensitive = true
-  default = null
-}
-
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type = string
-  default = null
-}
-
 variable "arcgis_server_patches" {
   description = "File names of ArcGIS Server patches to install."
   type        = list(string)

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
@@ -64,7 +64,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$AWS_DEFAULT_REGION"
-        terraform apply -var-file $CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Output
       id: output  
       run: echo arcgis_server_url=$(terraform output arcgis_server_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
@@ -53,7 +53,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$AWS_DEFAULT_REGION"
-          terraform destroy -var-file $APPLICATION_CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD -auto-approve
+          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
       - name: Destroy Infrastructure
         id: infrastructure-destroy
         working-directory: aws/arcgis-server-linux/infrastructure

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-image.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-image.yaml
@@ -54,4 +54,4 @@ jobs:
         id: packer
         run: |
           packer init .
-          packer build -var-file=$CONFIG_FILE -var=arcgis_online_username=$ARCGIS_ONLINE_USERNAME -var=arcgis_online_password=$ARCGIS_ONLINE_PASSWORD .
+          packer build -var-file=$CONFIG_FILE .

--- a/aws/modules/s3_copy_files/README.md
+++ b/aws/modules/s3_copy_files/README.md
@@ -31,8 +31,6 @@ On the machine where Terraform is executed:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| arcgis_online_password | ArcGIS Online user password | `string` | `null` | no |
-| arcgis_online_username | ArcGIS Online user name | `string` | `null` | no |
 | bucket_name | S3 bucket name | `string` | n/a | yes |
 | index_file | Index file local path | `string` | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/aws/modules/s3_copy_files/main.tf
+++ b/aws/modules/s3_copy_files/main.tf
@@ -40,8 +40,6 @@ terraform {
 }
 
 locals {
-  username_param = var.arcgis_online_username == null ? "" : "-u ${var.arcgis_online_username}"
-  password_param = var.arcgis_online_password == null ? "" : "-p ${var.arcgis_online_password}"
 }
 
 resource "null_resource" "s3_copy_files" {
@@ -50,6 +48,6 @@ resource "null_resource" "s3_copy_files" {
   }
     
   provisioner "local-exec" {
-    command = "python -m s3_copy_files -f ${var.index_file} -b ${var.bucket_name} ${local.username_param} ${local.password_param}"
+    command = "python -m s3_copy_files -f ${var.index_file} -b ${var.bucket_name}"
   }
 }

--- a/aws/modules/s3_copy_files/variables.tf
+++ b/aws/modules/s3_copy_files/variables.tf
@@ -26,16 +26,3 @@ variable "index_file" {
   description = "Index file local path"
   type = string
 } 
-
-variable "arcgis_online_username" {
-  description = "ArcGIS Online user name"
-  type = string
-  default = null
-}
-
-variable "arcgis_online_password" {
-  description = "ArcGIS Online user password"
-  type = string
-  sensitive = true
-  default = null
-}

--- a/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
@@ -5,8 +5,6 @@
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
   "arcgis_data_store_patches": [],
-  "arcgis_online_password": null,
-  "arcgis_online_username": null,
   "arcgis_portal_patches": [],
   "arcgis_server_patches": [],
   "arcgis_version": "11.3",

--- a/config/aws/arcgis-enterprise-base-linux/image.vars.json
+++ b/config/aws/arcgis-enterprise-base-linux/image.vars.json
@@ -2,8 +2,6 @@
     "arcgis_data_store_patches": [
         "ArcGIS-113-DS-*-linux.tar"
     ],
-    "arcgis_online_password": null,
-    "arcgis_online_username": null,
     "arcgis_portal_patches": [
         "ArcGIS-113-PFA-*-linux.tar"
     ],

--- a/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
@@ -5,8 +5,6 @@
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
   "arcgis_data_store_patches": [],
-  "arcgis_online_password": null,
-  "arcgis_online_username": null,
   "arcgis_portal_patches": [],
   "arcgis_server_patches": [],
   "arcgis_version": "11.3",

--- a/config/aws/arcgis-enterprise-base-windows/image.vars.json
+++ b/config/aws/arcgis-enterprise-base-windows/image.vars.json
@@ -2,8 +2,6 @@
     "arcgis_data_store_patches": [
         "ArcGIS-113-DS-*.msp"
     ],
-    "arcgis_online_password": null,
-    "arcgis_online_username": null,
     "arcgis_portal_patches": [
         "ArcGIS-113-PFA-*.msp"
     ],

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -2,8 +2,6 @@
   "admin_email": "<admin_email>",
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
-  "arcgis_online_password": null,
-  "arcgis_online_username": null,
   "arcgis_server_patches": [],
   "arcgis_version": "11.3",
   "config_store_type": "FILESYSTEM",

--- a/config/aws/arcgis-server-linux/image.vars.json
+++ b/config/aws/arcgis-server-linux/image.vars.json
@@ -1,6 +1,4 @@
 {
-    "arcgis_online_password": null,
-    "arcgis_online_username": null,
     "arcgis_server_patches": [
         "ArcGIS-113-S-*-linux.tar"
     ],


### PR DESCRIPTION
The PR removes arcgis_online_username and arcgis_online_password input variables form *-image and *-application workflows of arcgis-enterprise-base-linux, arcgis-enterprise-base-windows, and arcgis-server-linux templates.