### PR TITLE
#138 Removed java_version and tomcat_version input variables

### DIFF
--- a/ansible_collections/arcgis/server/playbooks/node.yaml
+++ b/ansible_collections/arcgis/server/playbooks/node.yaml
@@ -55,6 +55,10 @@
         admin_username: '{{ admin_username }}'
         admin_password: '{{ admin_password }}'
         primary_server_url: '{{ primary_server_url }}'
+    - name: Check if the keystore file exists
+      ansible.builtin.stat:
+        path: '{{ keystore_file }}'
+      register: keystore        
     - name: Configure SSL certificates in ArcGIS Server machine
       vars:
         ansible_aws_ssm_timeout: 600
@@ -68,3 +72,4 @@
         keystore_file: '{{ keystore_file }}'
         keystore_password: '{{ keystore_password }}'
         cert_alias: '{{ cert_alias }}'
+      when: keystore.stat.exists        

--- a/ansible_collections/arcgis/server/playbooks/primary.yaml
+++ b/ansible_collections/arcgis/server/playbooks/primary.yaml
@@ -74,6 +74,10 @@
         admin_password: '{{ admin_password }}'
         system_properties: '{{ system_properties }}'
         services_dir_enabled: '{{ services_dir_enabled }}'
+    - name: Check if the keystore file exists
+      ansible.builtin.stat:
+        path: '{{ keystore_file }}'
+      register: keystore        
     - name: Configure SSL certificates in ArcGIS Server machine
       vars:
         ansible_aws_ssm_timeout: 600
@@ -87,3 +91,4 @@
         keystore_file: '{{ keystore_file }}'
         keystore_password: '{{ keystore_password }}'
         cert_alias: '{{ cert_alias }}'
+      when: keystore.stat.exists

--- a/ansible_collections/arcgis/webadaptor/playbooks/openjdk.yml
+++ b/ansible_collections/arcgis/webadaptor/playbooks/openjdk.yml
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This playbook installs OpenJDK on all hosts.
+# Variables:
+# - local_repository: Path to the local repository where the JDK setup archive is stored.
+# - jdk_version: Version of the JDK to be installed.
+# - jdk_setup_archive: Name of the JDK setup archive file.
+# - install_dir: Directory where the JDK will be installed.
+# 
+# Tasks:
+# 1. Extract setup archive: Extracts the JDK setup archive to the specified installation directory.
+# 2. Display java alternatives: Displays the current java alternatives configuration.
+# 3. Remove java alternatives: Removes all existing java alternatives if any are found.
+# 4. Update java alternatives: Updates the java alternatives to point to the newly installed JDK.
+
 - name: Install OpenJDK
   hosts: all
   vars:

--- a/ansible_collections/arcgis/webadaptor/playbooks/templates/server.xml.j2
+++ b/ansible_collections/arcgis/webadaptor/playbooks/templates/server.xml.j2
@@ -86,9 +86,9 @@
                maxThreads="150" SSLEnabled="true">
         <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
         <SSLHostConfig>
-            <Certificate certificateKeystoreFile="{{ keystore_file }}"
-                         certificateKeystorePassword="{{ keystore_password }}"
-                         certificateKeystoreType="{{ keystore_type }}"
+            <Certificate certificateKeystoreFile="{{ certificate_keystore_file }}"
+                         certificateKeystorePassword="{{ certificate_keystore_password }}"
+                         certificateKeystoreType="{{ certificate_keystore_type }}"
                          type="RSA" />
         </SSLHostConfig>
     </Connector>

--- a/ansible_collections/arcgis/webadaptor/playbooks/tomcat_ssl_config.yml
+++ b/ansible_collections/arcgis/webadaptor/playbooks/tomcat_ssl_config.yml
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The playbook configures SSL in server.xml file of Apache Tomcat.
+# If the keystore file does not exist, the playbook creates a self-signed certificate and a PKCS12 file.
+# If the keystore file exists, the playbook just updates the server.xml file with the keystore information.
+
 - name: Configure SSL in Apache Tomcat
   hosts: all
   vars:
@@ -47,14 +51,26 @@
     - name: Generate PKCS12 file
       community.crypto.openssl_pkcs12:
         action: export
-        path: '{{ keystore_file }}'
+        path: '{{ install_dir }}/tomcat_{{ instance_name }}/conf/certificate.pfx'
         privatekey_path: '{{ install_dir }}/tomcat_{{ instance_name }}/conf/certificate.key'
         certificate_path: '{{ install_dir }}/tomcat_{{ instance_name }}/conf/certificate.pem'
-        passphrase: '{{ keystore_password }}' 
+        passphrase: 'test' 
         friendly_name: 'tomcat'
         owner: '{{ tomcat_user }}'
         state: present
-      when: not keystore.stat.exists                
+      when: not keystore.stat.exists
+    - name: Use self-signed certificate
+      ansible.builtin.set_fact:
+        certificate_keystore_file: '{{ install_dir }}/tomcat_{{ instance_name }}/conf/certificate.pfx'
+        certificate_keystore_password: 'test'
+        certificate_keystore_type: 'PKCS12'
+      when: not keystore.stat.exists                        
+    - name: Use external keystore file
+      ansible.builtin.set_fact:
+        certificate_keystore_file: '{{ keystore_file }}'
+        certificate_keystore_password: '{{ keystore_password }}'
+        certificate_keystore_type: '{{ keystore_type }}'
+      when: keystore.stat.exists                        
     - name: Update server.xml
       ansible.builtin.template:
         src: 'server.xml.j2'

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -115,7 +115,6 @@ The module uses the following SSM parameters:
 | deployment_fqdn | Fully qualified domain name of the base ArcGIS Enterprise deployment | `string` | n/a | yes |
 | deployment_id | Deployment Id | `string` | `"arcgis-enterprise-base"` | no |
 | is_upgrade | Flag to indicate if this is an upgrade deployment | `bool` | `false` | no |
-| java_version | OpenJDK version | `string` | `"11.0.21"` | no |
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
@@ -129,7 +128,6 @@ The module uses the following SSM parameters:
 | server_authorization_file_path | Local path of ArcGIS Server authorization file | `string` | n/a | yes |
 | server_authorization_options | Additional ArcGIS Server software authorization command line options | `string` | `""` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis-enterprise"` | no |
-| tomcat_version | Apache Tomcat version | `string` | `"9.0.83"` | no |
 
 ## Outputs
 

--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -83,18 +83,6 @@ variable "run_as_user" {
   default     = "arcgis"
 }
 
-variable "java_version" {
-  description = "OpenJDK version"
-  type        = string
-  default     = "11.0.21"
-}
-
-variable "tomcat_version" {
-  description = "Apache Tomcat version"
-  type        = string
-  default     = "9.0.83"
-}
-
 variable "server_authorization_file_path" {
   description = "Local path of ArcGIS Server authorization file"
   type        = string

--- a/aws/arcgis-enterprise-base-linux/image/README.md
+++ b/aws/arcgis-enterprise-base-linux/image/README.md
@@ -56,10 +56,8 @@ The template uses the following SSM parameters:
 | arcgis_version | ArcGIS Enterprise version | `string` | `"11.4"` | no |
 | arcgis_web_adaptor_patches | File names of ArcGIS Web Adaptor patches to install | `string` | `[]` | no |
 | instance_type | EC2 instance type | `string` | `"6i.xlarge"` | no |
-| java_version | OpenJDK version | `string` | `"11.0.21"` | no |
 | os | Operating system | `string` | `"rhel8"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |
 | run_as_user | User account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store | `string` | `"arcgis"` | no |
 | site_id | ArcGIS site Id | `string` | `"arcgis-enterprise"` | no |
 | skip_create_ami | If true, Packer will not create the AMI | `bool` | `false` | no |
-| tomcat_version | Apache Tomcat version | `string` | `"9.0.83"` | no |

--- a/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
@@ -85,18 +85,6 @@ variable "run_as_user" {
   default     = "arcgis"
 }
 
-variable "java_version" {
-  description = "OpenJDK version"
-  type        = string
-  default    = "11.0.21"
-}
-
-variable "tomcat_version" {
-  description = "Apache Tomcat version"
-  type        = string
-  default     = "9.0.83"
-}
-
 variable "arcgis_portal_patches" {
   description = "File names of Portal for ArcGIS patches to install."
   type        = list(string)

--- a/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.0.json
+++ b/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.0.json
@@ -24,6 +24,12 @@
         ],
         "subfolder": "software/arcgis/11.0/patches"        
       },
+      "metadata": {
+        "java_tarball": "jdk-11.0.21.tar.gz",
+        "java_version": "11.0.21+9",
+        "tomcat_tarball": "apache-tomcat-9.0.83.tar.gz",
+        "tomcat_version": "9.0.83"
+      },
       "files": {
         "ArcGIS_Server_Linux_110_182973.tar.gz": {
           "subfolder": "software/arcgis/11.0",

--- a/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.1.json
+++ b/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.1.json
@@ -24,6 +24,12 @@
         ],
         "subfolder": "software/arcgis/11.1/patches"        
       },
+      "metadata": {
+        "java_tarball": "jdk-11.0.21.tar.gz",
+        "java_version": "11.0.21+9",
+        "tomcat_tarball": "apache-tomcat-9.0.83.tar.gz",
+        "tomcat_version": "9.0.83"
+      },
       "files": {
         "ArcGIS_Server_Linux_111_185292.tar.gz": {
           "subfolder": "software/arcgis/11.1",

--- a/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.2.json
+++ b/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.2.json
@@ -24,6 +24,12 @@
         ],
         "subfolder": "software/arcgis/11.2/patches"        
       },
+      "metadata": {
+        "java_tarball": "jdk-11.0.21.tar.gz",
+        "java_version": "11.0.21+9",
+        "tomcat_tarball": "apache-tomcat-9.0.83.tar.gz",
+        "tomcat_version": "9.0.83"
+      },
       "files": {
         "ArcGIS_Server_Linux_112_188327.tar.gz": {
           "subfolder": "software/arcgis/11.2",

--- a/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.3.json
+++ b/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.3.json
@@ -24,6 +24,12 @@
         ],
         "subfolder": "software/arcgis/11.3/patches"        
       },
+      "metadata": {
+        "java_tarball": "jdk-11.0.21.tar.gz",
+        "java_version": "11.0.21+9",
+        "tomcat_tarball": "apache-tomcat-9.0.83.tar.gz",
+        "tomcat_version": "9.0.83"
+      },
       "files": {
         "ArcGIS_Server_Linux_113_190305.tar.gz": {
           "subfolder": "software/arcgis/11.3",

--- a/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.4.json
+++ b/aws/arcgis-enterprise-base-linux/manifests/arcgis-enterprise-s3files-11.4.json
@@ -24,6 +24,12 @@
         ],
         "subfolder": "software/arcgis/11.4/patches"        
       },
+      "metadata": {
+        "java_tarball": "jdk-11.0.21.tar.gz",
+        "java_version": "11.0.21+9",
+        "tomcat_tarball": "apache-tomcat-9.0.83.tar.gz",
+        "tomcat_version": "9.0.83"
+      },
       "files": {
         "ArcGIS_Server_Linux_114_192977.tar.gz": {
           "subfolder": "software/arcgis/11.4",

--- a/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.0.json
+++ b/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.0.json
@@ -24,6 +24,10 @@
         ],
         "subfolder": "software/arcgis/11.0/patches"
       },
+      "metadata": {
+        "dotnet_setup": "dotnet-hosting-win.exe",
+        "web_deploy_setup": "WebDeploy_amd64_en-US.msi"
+      },
       "files": {
         "ArcGIS_Server_Windows_110_182874.exe": {
           "subfolder": "software/arcgis/11.0",

--- a/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.1.json
+++ b/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.1.json
@@ -25,6 +25,10 @@
         ],
         "subfolder": "software/arcgis/11.1/patches"
       },
+      "metadata": {
+        "dotnet_setup": "dotnet-hosting-win.exe",
+        "web_deploy_setup": "WebDeploy_amd64_en-US.msi"
+      },
       "files": {
         "ArcGIS_Server_Windows_111_185208.exe": {
           "subfolder": "software/arcgis/11.1",

--- a/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.2.json
+++ b/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.2.json
@@ -23,7 +23,11 @@
           "ArcGIS-112-*.msp"
         ],
         "subfolder": "software/arcgis/11.2/patches"
-      },      
+      },
+      "metadata": {
+        "dotnet_setup": "dotnet-hosting-win.exe",
+        "web_deploy_setup": "WebDeploy_amd64_en-US.msi"
+      },
       "files": {
         "ArcGIS_Server_Windows_112_188239.exe": {
           "subfolder": "software/arcgis/11.2",

--- a/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.3.json
+++ b/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.3.json
@@ -23,7 +23,11 @@
           "ArcGIS-113-*.msp"
         ],
         "subfolder": "software/arcgis/11.3/patches"
-      },      
+      },
+      "metadata": {
+        "dotnet_setup": "dotnet-hosting-win.exe",
+        "web_deploy_setup": "WebDeploy_amd64_en-US.msi"
+      },
       "files": {
         "ArcGIS_Server_Windows_113_190188.exe": {
           "subfolder": "software/arcgis/11.3",

--- a/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.4.json
+++ b/aws/arcgis-enterprise-base-windows/manifests/arcgis-enterprise-s3files-11.4.json
@@ -23,7 +23,11 @@
           "ArcGIS-114-*.msp"
         ],
         "subfolder": "software/arcgis/11.4/patches"
-      },      
+      },
+      "metadata": {
+        "dotnet_setup": "dotnet-hosting-win.exe",
+        "web_deploy_setup": "WebDeploy_amd64_en-US.msi"
+      },
       "files": {
         "ArcGIS_Server_Windows_114_192938.exe": {
           "subfolder": "software/arcgis/11.4",

--- a/aws/arcgis-server-linux/manifests/arcgis-server-s3files-11.2.json
+++ b/aws/arcgis-server-linux/manifests/arcgis-server-s3files-11.2.json
@@ -1,8 +1,8 @@
 {
   "arcgis": {
     "repository": {
-      "local_archives": "{{ local_repository }}",
-      "local_patches": "{{ local_repository }}/patches",
+      "local_archives": "/opt/software/archives",
+      "local_patches": "/opt/software/archives/patches",
       "server": {
         "url": "https://downloads.arcgis.com",
         "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",

--- a/aws/arcgis-server-linux/manifests/arcgis-server-s3files-11.3.json
+++ b/aws/arcgis-server-linux/manifests/arcgis-server-s3files-11.3.json
@@ -2,8 +2,8 @@
     "arcgis": {
         "version": "11.3",
         "repository": {
-            "local_archives": "{{ local_repository }}",
-            "local_patches": "{{ local_repository }}/patches",
+            "local_archives": "/opt/software/archives",
+            "local_patches": "/opt/software/archives/patches",
             "server": {
                 "url": "https://downloads.arcgis.com",
                 "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",

--- a/aws/arcgis-server-linux/manifests/arcgis-server-s3files-11.4.json
+++ b/aws/arcgis-server-linux/manifests/arcgis-server-s3files-11.4.json
@@ -2,8 +2,8 @@
     "arcgis": {
         "version": "11.4",
         "repository": {
-            "local_archives": "{{ local_repository }}",
-            "local_patches": "{{ local_repository }}/patches",
+            "local_archives": "/opt/software/archives",
+            "local_patches": "/opt/software/archives/patches",
             "server": {
                 "url": "https://downloads.arcgis.com",
                 "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",

--- a/aws/arcgis-server-linux/manifests/arcgis-webadaptor-s3files-11.2.json
+++ b/aws/arcgis-server-linux/manifests/arcgis-webadaptor-s3files-11.2.json
@@ -1,8 +1,8 @@
 {
   "arcgis": {
     "repository": {
-      "local_archives": "{{ local_repository }}",
-      "local_patches": "{{ local_repository }}/patches",
+      "local_archives": "/opt/software/archives",
+      "local_patches": "/opt/software/archives/patches",
       "server": {
         "url": "https://downloads.arcgis.com",
         "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",
@@ -22,18 +22,23 @@
         ],
         "subfolder": "software/arcgis/11.2/patches"
       },
+      "metadata": {
+        "java_tarball": "OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz",
+        "java_version": "17.0.9+9",
+        "tomcat_tarball": "apache-tomcat-9.0.48.tar.gz",
+        "tomcat_version": "9.0.48"
+      },       
       "files": {
         "ArcGIS_Web_Adaptor_Java_Linux_112_188341.tar.gz": {
           "subfolder": "software/arcgis/11.2",
           "sha256": "AA4DBFC91CE7ABBE156E25D8ECFCD662F1D0771EF40D1B06B06A95E7DB88254E"
         },
-        "tomcat.tar.gz": {
+        "apache-tomcat-9.0.48.tar.gz": {
           "url": "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.48/bin/apache-tomcat-9.0.48.tar.gz",
           "subfolder": "software/thirdparty/11.2",
-          "sha256": "9CA3AD448505E05E6D057A9D71C120FBED3F042975A4B000C7135017C96B00AA",
-          "version": "9.0.48"
+          "sha256": "9CA3AD448505E05E6D057A9D71C120FBED3F042975A4B000C7135017C96B00AA"
         },
-        "jdk_x64_linux.tar.gz": {
+        "OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz": {
           "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz",
           "subfolder": "software/thirdparty/11.2",
           "sha256": "7B175DBE0D6E3C9C23B6ED96449B018308D8FC94A5ECD9C0DF8B8BC376C3C18A",

--- a/aws/arcgis-server-linux/manifests/arcgis-webadaptor-s3files-11.3.json
+++ b/aws/arcgis-server-linux/manifests/arcgis-webadaptor-s3files-11.3.json
@@ -1,8 +1,8 @@
 {
   "arcgis": {
     "repository": {
-      "local_archives": "{{ local_repository }}",
-      "local_patches": "{{ local_repository }}/patches",
+      "local_archives": "/opt/software/archives",
+      "local_patches": "/opt/software/archives/patches",
       "server": {
         "url": "https://downloads.arcgis.com",
         "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",
@@ -22,22 +22,27 @@
         ],
         "subfolder": "software/arcgis/11.3/patches"
       },
+      "metadata": {
+        "java_tarball": "OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz",
+        "java_version": "17.0.12+7",
+        "tomcat_tarball": "apache-tomcat-9.0.91.tar.gz",
+        "tomcat_version": "9.0.91"
+      },      
       "files": {
         "ArcGIS_Web_Adaptor_Java_Linux_113_190319.tar.gz": {
           "subfolder": "software/arcgis/11.3",
           "sha256": "F472D09125AC6E539A5FEDDDEC4D2540A3529E12C302CCE2D576B55F69708C03"
         },
-        "tomcat.tar.gz": {
+        "apache-tomcat-9.0.91.tar.gz": {
           "url": "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.91/bin/apache-tomcat-9.0.91.tar.gz",
           "subfolder": "software/thirdparty/11.3",
           "sha256": "0C5B29CA1D3A31BBB8FAB6AD1FEED8A3702ED325D14839550A6774C76C90B856",
           "version": "9.0.91"
         },
-        "jdk_x64_linux.tar.gz": {
+        "OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz": {
           "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz",
           "subfolder": "software/thirdparty/11.3",
-          "sha256": "9D4DD339BF7E6A9DCBA8347661603B74C61AB2A5083AE67BF76DA6285DA8A778",
-          "version": "17.0.12+7"
+          "sha256": "9D4DD339BF7E6A9DCBA8347661603B74C61AB2A5083AE67BF76DA6285DA8A778"
         }
       }
     }

--- a/aws/arcgis-server-linux/manifests/arcgis-webadaptor-s3files-11.4.json
+++ b/aws/arcgis-server-linux/manifests/arcgis-webadaptor-s3files-11.4.json
@@ -1,8 +1,8 @@
 {
   "arcgis": {
     "repository": {
-      "local_archives": "{{ local_repository }}",
-      "local_patches": "{{ local_repository }}/patches",
+      "local_archives": "/opt/software/archives",
+      "local_patches": "/opt/software/archives/patches",
       "server": {
         "url": "https://downloads.arcgis.com",
         "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",
@@ -22,22 +22,26 @@
         ],
         "subfolder": "software/arcgis/11.4/patches"
       },
+      "metadata": {
+        "java_tarball": "OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz",
+        "java_version": "17.0.12+7",
+        "tomcat_tarball": "apache-tomcat-9.0.91.tar.gz",
+        "tomcat_version": "9.0.91"
+      },
       "files": {
         "ArcGIS_Web_Adaptor_Java_Linux_114_192983.tar.gz": {
           "subfolder": "software/arcgis/11.4",
           "sha256": "D01B9EBFF0FEA724266128F57369D0CAF9F4EC99C21DFA386634BAACAFBCBE55"
         },
-        "tomcat.tar.gz": {
+        "apache-tomcat-9.0.91.tar.gz": {
           "url": "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.91/bin/apache-tomcat-9.0.91.tar.gz",
           "subfolder": "software/thirdparty/11.4",
-          "sha256": "0C5B29CA1D3A31BBB8FAB6AD1FEED8A3702ED325D14839550A6774C76C90B856",
-          "version": "9.0.91"
+          "sha256": "0C5B29CA1D3A31BBB8FAB6AD1FEED8A3702ED325D14839550A6774C76C90B856"
         },
-        "jdk_x64_linux.tar.gz": {
+        "OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz": {
           "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz",
           "subfolder": "software/thirdparty/11.4",
-          "sha256": "9D4DD339BF7E6A9DCBA8347661603B74C61AB2A5083AE67BF76DA6285DA8A778",
-          "version": "17.0.12+7"
+          "sha256": "9D4DD339BF7E6A9DCBA8347661603B74C61AB2A5083AE67BF76DA6285DA8A778"
         }
       }
     }

--- a/aws/scripts/manifest_json_file_format.md
+++ b/aws/scripts/manifest_json_file_format.md
@@ -1,6 +1,6 @@
-# Repository Index JSON File Format
+# Manifest JSON File Format
 
-The index JSON files used by s3_copy_files python script define source and destination locations of files copied to the private repository S3 bucket.
+The manifest JSON files used by s3_copy_files python script define source and destination locations of files copied to the private repository S3 bucket.
 
 Example:
 
@@ -13,11 +13,10 @@ Example:
       "server": {
         "url": "https://downloads.arcgis.com",
         "token_service_url": "https://www.arcgis.com/sharing/rest/generateToken",
-        "s3bucket": "mybucket",
-        "region": "us-east-1"
+        "s3bucket": "${s3bucket}",
+        "region": "${region}"
       },
       "patch_notification": {
-        "url": "https://downloads.esri.com/patch_notification/patches.json",
         "products": [
           "Portal for ArcGIS",
           "ArcGIS Server",
@@ -25,17 +24,49 @@ Example:
           "ArcGIS Web Adaptor (Java)"
         ],
         "versions": [
-          "11.1"
+          "11.4"
         ],
         "patches": [
-          "ArcGIS-111-*.tar"
+          "ArcGIS-114-*-linux.tar"
         ],
-        "subfolder": "software/arcgis/11.1/patches"        
+        "subfolder": "software/arcgis/11.4/patches"        
+      },
+      "metadata": {
+        "java_tarball": "jdk-11.0.21.tar.gz",
+        "java_version": "11.0.21+9",
+        "tomcat_tarball": "apache-tomcat-9.0.83.tar.gz",
+        "tomcat_version": "9.0.83"
       },
       "files": {
-        "ArcGIS_Server_Linux_111_185292.tar.gz": {
-          "subfolder": "software/arcgis/11.1",
-          "sha256": "B76093569A5DE14D7AB4C86459CEF4D84083335B247EE4B0FB0C4E22FE429B37"
+        "ArcGIS_Server_Linux_114_192977.tar.gz": {
+          "subfolder": "software/arcgis/11.4",
+          "sha256": "1B766ECDF0B16635F195EBD25151C4E2E7755197C743AE8D25790A07CB4E9B61"
+        },
+        "Portal_for_ArcGIS_Linux_114_192978.tar.gz": {
+          "subfolder": "software/arcgis/11.4",
+          "sha256": "57B06474E1EE66047468307EF08E5C4F9FB2C5560282515DC4633D9B388EC0B5"
+        },
+        "Portal_for_ArcGIS_Web_Styles_Linux_114_192979.tar.gz": {
+          "subfolder": "software/arcgis/11.4",
+          "sha256": "06902133A7036D816350ABFD4B18A0E20D6D71B90F700CDE8D8DE81A628CAE2D" 
+        },
+        "ArcGIS_DataStore_Linux_114_192981.tar.gz": {
+          "subfolder": "software/arcgis/11.4",
+          "sha256": "8207EA907EFD2E2ADDDBF95AB05A1740A7FC5EE2E521C9E3DB473A4286426C16"
+        },
+        "ArcGIS_Web_Adaptor_Java_Linux_114_192983.tar.gz": {
+          "subfolder": "software/arcgis/11.4",
+          "sha256": "D01B9EBFF0FEA724266128F57369D0CAF9F4EC99C21DFA386634BAACAFBCBE55"
+        },
+        "apache-tomcat-9.0.83.tar.gz": {
+          "url": "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.83/bin/apache-tomcat-9.0.83.tar.gz",
+          "subfolder": "thirdparty",
+          "sha256": "76092DAE89DC1F3AE6DD11404D64852761A401F18CD373C93B5FF7EF2CE4F90A"
+        },
+        "jdk-11.0.21.tar.gz": {
+          "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.21_9.tar.gz",
+          "subfolder": "thirdparty",
+          "sha256": "60EA98DAA09834FDD3162CA91DDC8D92A155AB3121204F6F643176EE0C2D0D5E"
         }
       }
     }
@@ -62,6 +93,10 @@ My Esri repository and ArcGIS Online token service URLs are specified by `arcgis
 
 * `arcgis.repository.server.url` - My Esri repository URL (default value is `https://downloads.arcgis.com`)
 * `arcgis.repository.server.token_service_url` - ArcGIS Online token service URL (default value is `https://www.arcgis.com/sharing/rest/generateToken`)
+
+## Metadata
+
+`arcgis.repository.metadata` attribute specifies the metadata of the repository files such as versions and version-specific properties.
 
 ## Individual Files
 
@@ -91,4 +126,4 @@ If neither `arcgis.repository.files.<filename>.url` nor `arcgis.repository.files
 
 ## Chef Run List
 
-> Note that the index JSON files are also used by arcgis-repository::s3files2 recipe of Chef Cookbooks for ArcGIS to download files and patches from the private S3 repository to local folder specified by `arcgis.repository.local_archives` and `arcgis.repository.local_patches` attributes respectively.
+> Note that the manifest JSON files are also used by arcgis-repository::s3files2 recipe of Chef Cookbooks for ArcGIS to download files and patches from the private S3 repository to local folder specified by `arcgis.repository.local_archives` and `arcgis.repository.local_patches` attributes respectively.

--- a/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
@@ -13,7 +13,6 @@
   "deployment_id": "arcgis-enterprise-base",
   "deployment_fqdn": "<deployment_fqdn>",
   "is_upgrade": false,
-  "java_version": "11.0.21",
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
@@ -26,6 +25,5 @@
   "security_question_answer": "<security_question_answer>",
   "server_authorization_file_path": "~/config/authorization/11.4/server_114.prvc",
   "server_authorization_options": "",
-  "site_id": "arcgis-enterprise",
-  "tomcat_version": "9.0.83"
+  "site_id": "arcgis-enterprise"
 }

--- a/config/aws/arcgis-enterprise-base-linux/image.vars.json
+++ b/config/aws/arcgis-enterprise-base-linux/image.vars.json
@@ -12,11 +12,9 @@
     "arcgis_web_adaptor_patches": [],
     "deployment_id": "arcgis-enterprise-base",
     "instance_type": "m6i.2xlarge",
-    "java_version": "11.0.21",
     "os": "rhel8",
     "root_volume_size": 100,
     "run_as_user": "arcgis",
     "site_id": "arcgis-enterprise",
-    "skip_create_ami": false,
-    "tomcat_version": "9.0.83"
+    "skip_create_ami": false
 }


### PR DESCRIPTION
The fix:

1. Moves version-specific properties of Open JDK and Apache Tomcat to "arcgis.repository.metadata" section of the manifest JSON files.
2. Removes java_version and tomcat_version input variables from arcgis-enterprise-base-linux/image Packer template and  arcgis-enterprise-base-linux/application module.
3. Updates arcgis-server-linux template to retrieve tomcat and java versions from "arcgis.repository.metadata" section of the manifest JSON instead of "version" properties instead of using fixed names for jdk and tomcat archives.
4. Makes the Packer templates and Terraform modules retrieve arcgis.repository.archives and arcgis.repository.patches values from the manifest JSON files.
5. Fixes an issue with updating Tomcat's SSL certificates in arcgis.server and arcgis.webadaptor Ansible collections.
6. Renames "index" files to "manifest" files.