### PR TITLE
#137 Fixed regression in enterprise-k8s-*-image workflows

### DIFF
--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-image.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-image.yaml
@@ -41,14 +41,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-      - name: Clean up space
+      - name: Free Disk Space
         run: |
-          # Clean up space for the image copy
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          docker rmi node:16 node:18 node:20 > /dev/null 2>&1
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
       - name: Copy Docker Hub images
         run: |
           AWS_DEFAULT_REGION=$(jq -r '.aws_region' $CONFIG_FILE)

--- a/azure/arcgis-enterprise-k8s/workflows/enterprise-k8s-azure-image.yaml
+++ b/azure/arcgis-enterprise-k8s/workflows/enterprise-k8s-azure-image.yaml
@@ -39,14 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-      - name: Clean up space
-        run: |
-          # Clean up space for the image copy
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          docker rmi node:16 node:18 node:20 > /dev/null 2>&1
       - name: Build Admin CLI Image
         run: |
           SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)


### PR DESCRIPTION
The PR fixes regression in enterprise-k8s-aws-image and enterprise-k8s-azure-image workflows that failed after upgrading runs-on image from ubuntu-22.04 to ubuntu-24.04.