### PR TITLE
#151 Don't log admin credentials in test workflows

### DIFF
--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-test.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-test.yaml
@@ -44,4 +44,4 @@ jobs:
         ARCGIS_ENTERPRISE_CONTEXT=portal
         ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
         ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
-        docker run enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT -u $ADMIN_USERNAME -p $ADMIN_PASSWORD
+        docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-test.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-test.yaml
@@ -44,4 +44,4 @@ jobs:
         ARCGIS_ENTERPRISE_CONTEXT=portal
         ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
         ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
-        docker run enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT -u $ADMIN_USERNAME -p $ADMIN_PASSWORD
+        docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-test.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-test.yaml
@@ -44,4 +44,4 @@ jobs:
         ARCGIS_ENTERPRISE_CONTEXT=arcgis
         ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
         ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
-        docker run enterprise-admin-cli gis test-server-admin --url https://$DEPLOYMENT_FQDN:6443/$ARCGIS_ENTERPRISE_CONTEXT -u $ADMIN_USERNAME -p $ADMIN_PASSWORD
+        docker run -e ARCGIS_SERVER_USER=$ADMIN_USERNAME -e ARCGIS_SERVER_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-server-admin --url https://$DEPLOYMENT_FQDN:6443/$ARCGIS_ENTERPRISE_CONTEXT


### PR DESCRIPTION
The PR modifies the test workflows to pass ArcGIS Enterprise site admin credentials to the Docker container using environment variables instead of command line parameters to prevent them from being logged in the docker run logs.