### PR TITLE
#153 Renamed deprecated webgisdr properties

### DIFF
--- a/aws/arcgis-enterprise-base-linux/backup/main.tf
+++ b/aws/arcgis-enterprise-base-linux/backup/main.tf
@@ -102,8 +102,12 @@ module "arcgis_enterprise_webgisdr_export" {
           S3_BUCKET                       = module.site_core_info.s3_backup
           S3_CREDENTIALTYPE               = "IAMRole"
           S3_REGION                       = module.site_core_info.s3_region
+          # In 11.4 PORTAL_BACKUP_S3_BUCKET property was renamed to BACKUP_S3_BUCKET
+          # Keeping both properties for backward compatibility
           BACKUP_S3_BUCKET                = module.site_core_info.s3_backup
           BACKUP_S3_REGION                = module.site_core_info.s3_region
+          PORTAL_BACKUP_S3_BUCKET         = module.site_core_info.s3_backup
+          PORTAL_BACKUP_S3_REGION         = module.site_core_info.s3_region
         }
       }
     }

--- a/aws/arcgis-enterprise-base-linux/restore/main.tf
+++ b/aws/arcgis-enterprise-base-linux/restore/main.tf
@@ -102,8 +102,12 @@ module "arcgis_enterprise_webgisdr_import" {
           S3_CREDENTIALTYPE               = "IAMRole"
           S3_REGION                       = module.site_core_info.s3_region
           #S3_BACKUP_NAME                 = "<backup file name>"
+          # In 11.4 PORTAL_BACKUP_S3_BUCKET property was renamed to BACKUP_S3_BUCKET
+          # Keeping both properties for backward compatibility
           BACKUP_S3_BUCKET                = module.site_core_info.s3_backup
           BACKUP_S3_REGION                = module.site_core_info.s3_region
+          PORTAL_BACKUP_S3_BUCKET         = module.site_core_info.s3_backup
+          PORTAL_BACKUP_S3_REGION         = module.site_core_info.s3_region
         }
       }
     }

--- a/aws/arcgis-enterprise-base-windows/backup/main.tf
+++ b/aws/arcgis-enterprise-base-windows/backup/main.tf
@@ -103,8 +103,12 @@ module "arcgis_enterprise_webgisdr_export" {
           S3_BUCKET                       = module.site_core_info.s3_backup
           S3_CREDENTIALTYPE               = "IAMRole"
           S3_REGION                       = module.site_core_info.s3_region
+          # In 11.4 PORTAL_BACKUP_S3_BUCKET property was renamed to BACKUP_S3_BUCKET
+          # Keeping both properties for backward compatibility
           BACKUP_S3_BUCKET                = module.site_core_info.s3_backup
           BACKUP_S3_REGION                = module.site_core_info.s3_region
+          PORTAL_BACKUP_S3_BUCKET         = module.site_core_info.s3_backup
+          PORTAL_BACKUP_S3_REGION         = module.site_core_info.s3_region
         }
       }
     }

--- a/aws/arcgis-enterprise-base-windows/restore/main.tf
+++ b/aws/arcgis-enterprise-base-windows/restore/main.tf
@@ -103,8 +103,12 @@ module "arcgis_enterprise_webgisdr_import" {
           S3_CREDENTIALTYPE               = "IAMRole"
           S3_REGION                       = module.site_core_info.s3_region
           #S3_BACKUP_NAME                 = "<backup file name>"
+          # In 11.4 PORTAL_BACKUP_S3_BUCKET property was renamed to BACKUP_S3_BUCKET
+          # Keeping both properties for backward compatibility
           BACKUP_S3_BUCKET                = module.site_core_info.s3_backup
           BACKUP_S3_REGION                = module.site_core_info.s3_region
+          PORTAL_BACKUP_S3_BUCKET         = module.site_core_info.s3_backup
+          PORTAL_BACKUP_S3_REGION         = module.site_core_info.s3_region
         }
       }
     }


### PR DESCRIPTION
Added back PORTAL_BACKUP_S3_BUCKET and PORTAL_BACKUP_S3_REGION webgisdr properties to support ArcGIS Enterprise versions <= 11.3.