### PR TITLE
#158 Updated validate-settings-* workflows

### DIFF
--- a/.github/workflows/validate-settings-aws.yaml
+++ b/.github/workflows/validate-settings-aws.yaml
@@ -29,7 +29,7 @@ env:
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
 
 jobs:
-  validate_settings_aws:
+  validate_settings:
     name: Validate GitHub Actions secrets and variables
     runs-on: ubuntu-24.04
     permissions:
@@ -47,9 +47,10 @@ jobs:
       id: test-aws-credentials
       run: python -m test_aws_credentials -b $TERRAFORM_BACKEND_S3_BUCKET
     - name: Test ArcGIS Online credentials
+      if: ${{ env.ARCGIS_ONLINE_USERNAME }}
       id: test-arcgis-online-credentials
       run: python -m token_service_client 
     - name: Test Docker Hub credentials
-      if: ${{ env.CONTAINER_REGISTRY_USER }} 
+      if: ${{ env.CONTAINER_REGISTRY_USER }}
       id: test-docker-hub-credentials
       run: echo $CONTAINER_REGISTRY_PASSWORD | docker login --username $CONTAINER_REGISTRY_USER --password-stdin

--- a/.github/workflows/validate-settings-azure.yaml
+++ b/.github/workflows/validate-settings-azure.yaml
@@ -31,7 +31,7 @@ env:
   PYTHONPATH: ${{ github.workspace }}/azure/scripts
 
 jobs:
-  validate_settings_aws:
+  validate_settings:
     name: Validate GitHub Actions secrets and variables
     runs-on: ubuntu-24.04
     permissions:
@@ -47,7 +47,8 @@ jobs:
     - name: Test Azure credentials
       run: python -m test_azure_credentials -a $TERRAFORM_BACKEND_STORAGE_ACCOUNT_NAME -c $TERRAFORM_BACKEND_CONTAINER_NAME
     - name: Test ArcGIS Online credentials
-      run: python -m token_service_client 
+      if: ${{ env.ARCGIS_ONLINE_USERNAME }}
+      run: python -m token_service_client
     - name: Test Docker Hub credentials
-      if: ${{ env.CONTAINER_REGISTRY_USER }} 
+      if: ${{ env.CONTAINER_REGISTRY_USER }}
       run: echo $CONTAINER_REGISTRY_PASSWORD | docker login --username $CONTAINER_REGISTRY_USER --password-stdin


### PR DESCRIPTION
The fix makes validate-settings-azure and validate-settings-aws workflows skip "Test ArcGIS Online credentials" step if ARCGIS_ONLINE_USERNAME GitHub Actions secret is not set.