### PR TITLE
#160 Changed account_replication_type to GRS

### DIFF
--- a/azure/arcgis-enterprise-k8s/organization/modules/storage/main.tf
+++ b/azure/arcgis-enterprise-k8s/organization/modules/storage/main.tf
@@ -51,7 +51,7 @@ resource "azurerm_storage_account" "deployment_storage" {
   resource_group_name             = azurerm_resource_group.storage.name
   location                        = var.azure_region
   account_tier                    = "Standard"
-  account_replication_type        = "ZRS"
+  account_replication_type        = "GRS"
   public_network_access_enabled   = true
   shared_access_key_enabled       = false
   allow_nested_items_to_be_public = false

--- a/azure/arcgis-site-core/infrastructure-core/storage.tf
+++ b/azure/arcgis-site-core/infrastructure-core/storage.tf
@@ -31,7 +31,7 @@ resource "azurerm_storage_account" "site_storage" {
   resource_group_name             = azurerm_resource_group.site_rg.name
   location                        = azurerm_resource_group.site_rg.location
   account_tier                    = "Standard"
-  account_replication_type        = "ZRS"
+  account_replication_type        = "GRS"
   public_network_access_enabled   = true
   shared_access_key_enabled       = false
   allow_nested_items_to_be_public = false


### PR DESCRIPTION
 Changed account_replication_type from ZRS to GRS for site storage and arcgis-enterprise-k8s deployment Azure storage accounts.