### PR TITLE
#161 Updated azurerm provider and ALB controller versions

### DIFF
--- a/azure/arcgis-enterprise-k8s/ingress/README.md
+++ b/azure/arcgis-enterprise-k8s/ingress/README.md
@@ -30,7 +30,7 @@ On the machine where Terraform is executed:
 
 | Name | Version |
 |------|---------|
-| azurerm | ~> 4.6 |
+| azurerm | ~> 4.16 |
 | kubernetes | ~> 2.26 |
 
 ## Resources

--- a/azure/arcgis-enterprise-k8s/ingress/main.tf
+++ b/azure/arcgis-enterprise-k8s/ingress/main.tf
@@ -27,7 +27,7 @@
  * * AKS cluster configuration information must be provided in ~/.kube/config file.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.6"
+      version = "~> 4.16"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/azure/arcgis-enterprise-k8s/organization/README.md
+++ b/azure/arcgis-enterprise-k8s/organization/README.md
@@ -37,7 +37,7 @@ On the machine where Terraform is executed:
 
 | Name | Version |
 |------|---------|
-| azurerm | ~> 4.6 |
+| azurerm | ~> 4.16 |
 | helm | ~> 2.12 |
 | kubernetes | ~> 2.26 |
 | local | n/a |

--- a/azure/arcgis-enterprise-k8s/organization/main.tf
+++ b/azure/arcgis-enterprise-k8s/organization/main.tf
@@ -34,7 +34,7 @@
  * * AKS cluster configuration information must be provided in ~/.kube/config file.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.6"
+      version = "~> 4.16"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/azure/arcgis-site-core/infrastructure-core/README.md
+++ b/azure/arcgis-site-core/infrastructure-core/README.md
@@ -38,7 +38,7 @@ Attributes of the resources are stored as secrets in the Azure Key Vault created
 
 | Name | Version |
 |------|---------|
-| azurerm | ~> 4.6 |
+| azurerm | ~> 4.16 |
 | random | n/a |
 
 ## Resources

--- a/azure/arcgis-site-core/infrastructure-core/main.tf
+++ b/azure/arcgis-site-core/infrastructure-core/main.tf
@@ -35,7 +35,7 @@
  * * Azure service principal credentials must be configured by ARM_CLIENT_ID, ARM_TENANT_ID, and ARM_CLIENT_SECRET environment variables.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.6"
+      version = "~> 4.16"
     }
   }
 }

--- a/azure/arcgis-site-core/k8s-cluster/README.md
+++ b/azure/arcgis-site-core/k8s-cluster/README.md
@@ -30,7 +30,7 @@ On the machine where Terraform is executed:
 
 | Name | Version |
 |------|---------|
-| azurerm | ~> 4.6 |
+| azurerm | ~> 4.16 |
 | null | n/a |
 
 ## Modules

--- a/azure/arcgis-site-core/k8s-cluster/main.tf
+++ b/azure/arcgis-site-core/k8s-cluster/main.tf
@@ -27,7 +27,7 @@
  * * Azure CLI, Helm and kubectl must be installed.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.6"
+      version = "~> 4.16"
     }
   }
 }

--- a/azure/arcgis-site-core/k8s-cluster/modules/alb-controller/README.md
+++ b/azure/arcgis-site-core/k8s-cluster/modules/alb-controller/README.md
@@ -45,7 +45,7 @@ Helm must be installed on the machine where terraform is executed.
 | alb_subnet_id | Subnet Id for the ALB | `string` | n/a | yes |
 | azure_region | Azure region display name | `string` | n/a | yes |
 | cluster_name | Name of the AKS cluster | `string` | n/a | yes |
-| controller_version | Version of the ALB Controller | `string` | `"1.2.3"` | no |
+| controller_version | Version of the ALB Controller | `string` | `"1.3.7"` | no |
 | resource_group_name | AKS cluster resource group name | `string` | n/a | yes |
 
 ## Outputs

--- a/azure/arcgis-site-core/k8s-cluster/modules/alb-controller/variables.tf
+++ b/azure/arcgis-site-core/k8s-cluster/modules/alb-controller/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ variable "cluster_name" {
 variable "controller_version" {
   description = "Version of the ALB Controller"
   type        = string
-  default     = "1.2.3"
+  default     = "1.3.7"
 }
 
 variable "alb_subnet_id" {

--- a/azure/arcgis-site-core/k8s-cluster/modules/container-registry/README.md
+++ b/azure/arcgis-site-core/k8s-cluster/modules/container-registry/README.md
@@ -19,7 +19,6 @@ Azure CLI must be installed on the machine where terraform is executed.
 | Name | Version |
 |------|---------|
 | azurerm | n/a |
-| null | n/a |
 | random | n/a |
 
 ## Resources
@@ -28,6 +27,8 @@ Azure CLI must be installed on the machine where terraform is executed.
 |------|------|
 | [azurerm_container_registry.cluster_acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
 | [azurerm_container_registry_cache_rule.pull_through_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_cache_rule) | resource |
+| [azurerm_container_registry_credential_set.credential_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_credential_set) | resource |
+| [azurerm_key_vault_access_policy.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.acr_login_server](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.acr_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.cr_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
@@ -36,7 +37,6 @@ Azure CLI must be installed on the machine where terraform is executed.
 | [azurerm_private_dns_zone_virtual_network_link.acr_private_dns_zone_virtual_network_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_endpoint.acr_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_role_assignment.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [null_resource.credential_set](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_id.container_registry_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [azurerm_key_vault.site_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 


### PR DESCRIPTION
1. Updated azurerm Terraform provider version to ~> 4.16
2. Updated ALB controller version to 1.3.7
3. Use new [azurerm_container_registry_credential_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_credential_set) resource to create container registry credential sets.