### PR TITLE
#169 Don't validate helm_charts_version

### DIFF
--- a/aws/arcgis-enterprise-k8s/organization/variables.tf
+++ b/aws/arcgis-enterprise-k8s/organization/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,11 +43,6 @@ variable "helm_charts_version" {
   description = "Helm Charts for ArcGIS Enterprise on Kubernetes version"
   type        = string
   default     = "1.4.0"
-
-  validation {
-    condition     = contains(["1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.3.4", "1.4.0"], var.helm_charts_version)
-    error_message = "Valid values for helm_charts_version variable are 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 1.3.4 and 1.4.0."
-  }
 }
 
 variable "upgrade_token" {

--- a/azure/arcgis-enterprise-k8s/organization/README.md
+++ b/azure/arcgis-enterprise-k8s/organization/README.md
@@ -87,7 +87,7 @@ On the machine where Terraform is executed:
 | deployment_id | ArcGIS Enterprise deployment Id | `string` | `"arcgis-enterprise-k8s"` | no |
 | enterprise_admin_cli_version | ArcGIS Enterprise Admin CLI image tag | `string` | `"0.4.0"` | no |
 | helm_charts_version | Helm Charts for ArcGIS Enterprise on Kubernetes version | `string` | `"1.4.0"` | no |
-| image_repository_prefix | Prefix of images in ECR repositories | `string` | `"docker-hub/esridocker"` | no |
+| image_repository_prefix | Prefix of images in ACR repositories | `string` | `"docker-hub/esridocker"` | no |
 | k8s_cluster_domain | Kubernetes cluster domain | `string` | `"cluster.local"` | no |
 | license_type_id | User type ID for the primary administrator account | `string` | `"creatorUT"` | no |
 | log_retention_max_days | Number of days logs will be retained by the organization | `number` | `60` | no |

--- a/azure/arcgis-enterprise-k8s/organization/modules/storage/main.tf
+++ b/azure/arcgis-enterprise-k8s/organization/modules/storage/main.tf
@@ -10,7 +10,7 @@
  * * Creates cloud config JSON file for the object store.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ resource "azurerm_storage_account" "deployment_storage" {
 # Create blob container for the organization object store if cloud_config_json_file_path is not specified.
 resource "azurerm_storage_container" "object_store" {
   name                  = "object-store"
-  storage_account_name  = azurerm_storage_account.deployment_storage.name
+  storage_account_id    = azurerm_storage_account.deployment_storage.id
   container_access_type = "private"
 }
 
@@ -128,9 +128,7 @@ resource "local_sensitive_file" "cloud_config_json_file" {
       usage = "DEFAULT"
       connection = {
         containerName = azurerm_storage_container.object_store.name
-        # regionEndpointUrl = "https://${module.site_core_info.storage_account_name}.blob.core.windows.net"
         accountEndpointUrl = trimsuffix(azurerm_storage_account.deployment_storage.primary_blob_endpoint, "/")
-        # rootDir = var.deployment_id
       }
       category = "storage"
     }]

--- a/azure/arcgis-enterprise-k8s/organization/variables.tf
+++ b/azure/arcgis-enterprise-k8s/organization/variables.tf
@@ -59,7 +59,7 @@ variable "mandatory_update_target_id" {
 }
 
 variable "image_repository_prefix" {
-  description = "Prefix of images in ECR repositories"
+  description = "Prefix of images in ACR repositories"
   type        = string
   default     = "docker-hub/esridocker"
 }

--- a/azure/arcgis-enterprise-k8s/organization/variables.tf
+++ b/azure/arcgis-enterprise-k8s/organization/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,11 +43,6 @@ variable "helm_charts_version" {
   description = "Helm Charts for ArcGIS Enterprise on Kubernetes version"
   type        = string
   default     = "1.4.0"
-
-  validation {
-    condition     = contains(["1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.3.4", "1.4.0"], var.helm_charts_version)
-    error_message = "Valid values for helm_charts_version variable are 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 1.3.4 and 1.4.0."
-  }
 }
 
 variable "upgrade_token" {

--- a/config/aws/arcgis-enterprise-k8s/organization.tfvars.json
+++ b/config/aws/arcgis-enterprise-k8s/organization.tfvars.json
@@ -12,6 +12,7 @@
   "deployment_fqdn": "<deployment_fqdn>",
   "deployment_id": "arcgis-enterprise-k8s",
   "helm_charts_version": "1.4.0",
+  "image_repository_prefix": "docker-hub/esridocker",
   "license_type_id": "creatorUT",
   "log_retention_max_days": 60,
   "log_setting": "INFO",

--- a/config/azure/arcgis-enterprise-k8s/organization.tfvars.json
+++ b/config/azure/arcgis-enterprise-k8s/organization.tfvars.json
@@ -12,6 +12,7 @@
   "deployment_fqdn": "<deployment_fqdn>",
   "deployment_id": "arcgis-enterprise-k8s",
   "helm_charts_version": "1.4.0",
+  "image_repository_prefix": "docker-hub/esridocker",
   "license_type_id": "creatorUT",
   "log_retention_max_days": 60,
   "log_setting": "INFO",


### PR DESCRIPTION
1. Removed validation for helm_charts_version input variable.
2. Replaced deprecated azurerm_storage_container.storage_account_name by azurerm_storage_container.storage_account_id.
3. Added "image_repository_prefix" set to "docker-hub/esridocker" to organization.tfvars.json.