### PR TITLE
#174 Use globally-unique Azure key vault name

### DIFF
--- a/azure/arcgis-enterprise-k8s/image/build-admin-cli-image.sh
+++ b/azure/arcgis-enterprise-k8s/image/build-admin-cli-image.sh
@@ -31,8 +31,9 @@ SITE_ID=$4
 
 az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
 
-ACR_NAME=$(az keyvault secret show --name acr-name --vault-name $SITE_ID --query value -o tsv)
-ACR_LOGIN_SERVER=$(az keyvault secret show --name acr-login-server --vault-name $SITE_ID --query value -o tsv)
+VAULT_NAME=$(az resource list --resource-group $SITE_ID-infrastructure-core --resource-type=Microsoft.KeyVault/vaults --query "[].{name:name}" -o tsv)
+ACR_NAME=$(az keyvault secret show --name acr-name --vault-name $VAULT_NAME --query value -o tsv)
+ACR_LOGIN_SERVER=$(az keyvault secret show --name acr-login-server --vault-name $VAULT_NAME --query value -o tsv)
 
 az acr login --name $ACR_NAME
 

--- a/azure/arcgis-enterprise-k8s/ingress/README.md
+++ b/azure/arcgis-enterprise-k8s/ingress/README.md
@@ -33,6 +33,12 @@ On the machine where Terraform is executed:
 | azurerm | ~> 4.16 |
 | kubernetes | ~> 2.26 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| site_core_info | ../../modules/site_core_info | n/a |
+
 ## Resources
 
 | Name | Type |
@@ -46,7 +52,6 @@ On the machine where Terraform is executed:
 | [kubernetes_namespace.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_secret.ca_bundle_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.listener_tls_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
-| [azurerm_key_vault.site_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.alb_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 
 ## Inputs

--- a/azure/arcgis-enterprise-k8s/ingress/main.tf
+++ b/azure/arcgis-enterprise-k8s/ingress/main.tf
@@ -68,15 +68,15 @@ provider "kubernetes" {
   config_path = "~/.kube/config"
 }
 
-data "azurerm_key_vault" "site_vault" {
-  name                = var.site_id
-  resource_group_name = "${var.site_id}-infrastructure-core"
+module "site_core_info" {
+  source  = "../../modules/site_core_info"
+  site_id = var.site_id
 }
 
 # Retrieve the Application Load Balancer ID from the Key Vault
 data "azurerm_key_vault_secret" "alb_id" {
   name         = "alb-id"
-  key_vault_id = data.azurerm_key_vault.site_vault.id
+  key_vault_id = module.site_core_info.vault_id
 }
 
 locals {

--- a/azure/arcgis-site-core/infrastructure-core/README.md
+++ b/azure/arcgis-site-core/infrastructure-core/README.md
@@ -48,10 +48,8 @@ Attributes of the resources are stored as secrets in the Azure Key Vault created
 | [azurerm_bastion_host.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/bastion_host) | resource |
 | [azurerm_key_vault.site_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_access_policy.current_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.app_gateway_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.internal_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.private_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.storage_account_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
 | [azurerm_nat_gateway_public_ip_association.nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
@@ -86,7 +84,7 @@ Attributes of the resources are stored as secrets in the Azure Key Vault created
 | [azurerm_subnet_network_security_group_association.internal_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_subnet_network_security_group_association.private_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_virtual_network.site_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
-| [random_id.storage_account_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.unique_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/azure/arcgis-site-core/infrastructure-core/storage.tf
+++ b/azure/arcgis-site-core/infrastructure-core/storage.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,12 @@
 
 # Storage account and blob containers for ArcGIS Enterprise site
 
-resource "random_id" "storage_account_suffix" {
-  keepers = {
-    # Generate a new id each time we switch to a new site id
-    site_id = var.site_id
-  }
-
-  byte_length = 8
-}
 
 # Create storage account for the site's repository, backups, and logs.
 # Public network access is enabled for the storage account because it is required
 # to create the blob containers.
 resource "azurerm_storage_account" "site_storage" {
-  name                            = "site${random_id.storage_account_suffix.hex}"
+  name                            = "site${random_id.unique_name_suffix.hex}"
   resource_group_name             = azurerm_resource_group.site_rg.name
   location                        = azurerm_resource_group.site_rg.location
   account_tier                    = "Standard"

--- a/azure/arcgis-site-core/k8s-cluster/modules/container-registry/README.md
+++ b/azure/arcgis-site-core/k8s-cluster/modules/container-registry/README.md
@@ -21,6 +21,12 @@ Azure CLI must be installed on the machine where terraform is executed.
 | azurerm | n/a |
 | random | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| site_core_info | ../../../../modules/site_core_info | n/a |
+
 ## Resources
 
 | Name | Type |
@@ -28,7 +34,7 @@ Azure CLI must be installed on the machine where terraform is executed.
 | [azurerm_container_registry.cluster_acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
 | [azurerm_container_registry_cache_rule.pull_through_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_cache_rule) | resource |
 | [azurerm_container_registry_credential_set.credential_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_credential_set) | resource |
-| [azurerm_key_vault_access_policy.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.pull_through_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.acr_login_server](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.acr_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.cr_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
@@ -38,7 +44,6 @@ Azure CLI must be installed on the machine where terraform is executed.
 | [azurerm_private_endpoint.acr_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_role_assignment.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [random_id.container_registry_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [azurerm_key_vault.site_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 
 ## Inputs
 

--- a/azure/modules/site_core_info/README.md
+++ b/azure/modules/site_core_info/README.md
@@ -16,13 +16,10 @@ returns them as output values.
 | Name | Type |
 |------|------|
 | [azurerm_key_vault.site_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.app_gateway_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.internal_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.private_subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.storage_account_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.storage_account_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.subnets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.vnet_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secrets.secrets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secrets) | data source |
+| [azurerm_resources.site_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resources) | data source |
 | [azurerm_storage_account.site_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 
 ## Inputs
@@ -41,7 +38,6 @@ returns them as output values.
 | resource_group_name | Resource Group Name |
 | storage_account_blob_endpoint | Azure storage account primary blob endpoint |
 | storage_account_id | Azure storage account Id |
-| storage_account_key | Azure storage account key |
 | storage_account_name | Azure storage account name |
 | vault_id | Azure Key Vault Id |
 | vault_name | Azure Key Vault Name |

--- a/azure/modules/site_core_info/main.tf
+++ b/azure/modules/site_core_info/main.tf
@@ -6,7 +6,7 @@
  * returns them as output values. 
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,39 +20,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "azurerm_key_vault" "site_vault" {
-  name                = var.site_id
+data "azurerm_resources" "site_vault" {
   resource_group_name = "${var.site_id}-infrastructure-core"
-}
 
-data "azurerm_key_vault_secrets" "secrets" {
-  key_vault_id = data.azurerm_key_vault.site_vault.id
-}
-
-data "azurerm_key_vault_secret" "app_gateway_subnets" {
-  for_each = {
-    for secret in data.azurerm_key_vault_secrets.secrets.names : secret => secret
-    if startswith(secret, "app-gateway-subnet")
+  required_tags = {
+    ArcGISSiteId = var.site_id
+    ArcGISRole   = "site-vault"
   }
-  name         = each.key
-  key_vault_id = data.azurerm_key_vault.site_vault.id
 }
 
-data "azurerm_key_vault_secret" "private_subnets" {
-  for_each = {
-    for secret in data.azurerm_key_vault_secrets.secrets.names : secret => secret
-    if startswith(secret, "private-subnet")
-  }
-  name         = each.key
-  key_vault_id = data.azurerm_key_vault.site_vault.id
+data "azurerm_key_vault" "site_vault" {
+  name                = data.azurerm_resources.site_vault.resources[0].name
+  resource_group_name = data.azurerm_resources.site_vault.resource_group_name
 }
 
-data "azurerm_key_vault_secret" "internal_subnets" {
-  for_each = {
-    for secret in data.azurerm_key_vault_secrets.secrets.names : secret => secret
-    if startswith(secret, "internal-subnet")
-  }
-  name         = each.key
+data "azurerm_key_vault_secret" "subnets" {
+  name         = "subnets"
   key_vault_id = data.azurerm_key_vault.site_vault.id
 }
 

--- a/azure/modules/site_core_info/outputs.tf
+++ b/azure/modules/site_core_info/outputs.tf
@@ -39,17 +39,17 @@ output "vnet_id" {
 
 output "app_gateway_subnets" {
   description = "Ids of app gateway subnets"
-  value       = values(data.azurerm_key_vault_secret.app_gateway_subnets).*.value
+  value       = jsondecode(data.azurerm_key_vault_secret.subnets.value).app_gateway
 }
 
 output "private_subnets" {
   description = "Ids of private subnets"
-  value       = values(data.azurerm_key_vault_secret.private_subnets).*.value
+  value       = jsondecode(data.azurerm_key_vault_secret.subnets.value).private
 }
 
 output "internal_subnets" {
   description = "Ids of internal subnets"
-  value       = values(data.azurerm_key_vault_secret.internal_subnets).*.value
+  value       = jsondecode(data.azurerm_key_vault_secret.subnets.value).internal
 }
 
 output "storage_account_name" {


### PR DESCRIPTION
The PR:

1. Uses a randomly generated name for the site's Azure key vault. 
2. Stores all the subnet IDs in JSON format in single "subnet" secret instead of one secret per each subnet.
