### PR TITLE
#181 Refactor backup and restore workflows to include backup_restore_mode input 

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -47,9 +47,11 @@ The following templates are available for AWS:
 
 By default, the workflows are configured with "workflow_dispatch" event that enables workflows to be triggered manually. To trigger a workflow manually, navigate to the repository on GitHub, click on the "Actions" tab, select the workflow to run, select the branch, and click the "Run workflow" button.
 
-> Note that the deployments may belong to different *environments* such as "production" and "staging". Each environment may have its own branch in the repository. The list of workflows in GitHub Actions page shows only the workflows present in /.github/workflows directory of the "main" branch, but the workflow runs use the workflow files from the selected branch. To enable workflows, copy the workflows' .yaml files from the template's `workflows` directory to `/.github/workflows` directory in both the `main` branch and the environment branch, commit the changes, and push the branches to GitHub.
+> Note that the deployments may belong to different *environments* such as "production" and "staging". Each environment may have its own branch in the repository. It's recommended to use protected `main` branch for the production environment and create separate branches for other environments.
+ 
+The list of workflows in GitHub Actions page shows only the workflows present in /.github/workflows directory of the "main" branch, but the workflow runs use the workflow files from the selected branch. To enable workflows, copy the workflows' .yaml files from the template's `workflows` directory to `/.github/workflows` directory in both the `main` branch and the environment branch, commit the changes, and push the branches to GitHub.
 
-The workflows can be modified to use other triggering events such as push, pull_request, or schedule. Consider using "schedule" event to schedule backups and "pull_request" event to check the infrastructure changes by "terraform plan" command.
+The workflows can be modified to use other triggering events such as push, pull_request, or schedule. Consider using "schedule" event to schedule backups and "pull_request" event to check the infrastructure changes by "terraform plan" command. Note that scheduled workflows run on the latest commit on the `main` (or default) branch.
 
 ## Configuration Files
 

--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -128,7 +128,7 @@ Instructions:
 2. Commit the changes to the Git branch and push the branch to GitHub.
 3. Run enterprise-base-linux-aws-backup workflow using the branch.
 
-> To meet the required recovery point objective (RPO), schedule runs of enterprise-base-linux-aws-backup workflow by configuring 'schedule' event in enterprise-base-linux-aws-backup.yaml file.
+To meet the required recovery point objective (RPO), schedule runs of enterprise-base-linux-aws-backup workflow by configuring 'schedule' event in enterprise-base-linux-aws-backup.yaml file. When the backup workflow is triggered manually, the backup-restore mode is specified by the workflow inputs. However, when the workflow is triggered on schedule, the backup-restore mode is retrieved from the backup.tfvars.json config file. Note that scheduled workflows run on the latest commit on the `main` (or default) branch.
 
 > Base ArcGIS Enterprise deployments in a site use the same S3 bucket for backups. Run backups only for the active deployment branch.
 

--- a/aws/arcgis-enterprise-base-linux/infrastructure/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/variables.tf
@@ -125,7 +125,7 @@ variable "root_volume_iops" {
   default     = 3000
 
   validation {
-    condition     = var.root_volume_iops >= 3000   && var.root_volume_iops <= 16000
+    condition     = var.root_volume_iops >= 3000 && var.root_volume_iops <= 16000
     error_message = "The root_volume_iops value must be between 3000 and 16000."
   }    
 }

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-backup.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-backup.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,16 @@ name: enterprise-base-linux-aws-backup
 
 on: 
   workflow_dispatch:
+    inputs:
+      backup_restore_mode:
+        description: 'Type of backup'
+        type: choice
+        options:
+        - backup
+        - full
+        - incremental
   # schedule:
-  #   - cron: '0 0 * * *'
+  # - cron: '0 0 * * *'
       
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -57,4 +65,9 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/backup.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        if [ ${{ github.event.inputs.backup_restore_mode }} != "" ]; then
+          terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
+        else 
+          terraform apply -var-file $CONFIG_FILE -auto-approve
+        fi
+        

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-restore.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-restore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,14 @@ name: enterprise-base-linux-aws-restore
 
 on: 
   workflow_dispatch:
+    inputs:
+      backup_restore_mode:
+        description: 'Type of backup'
+        type: choice
+        options:
+        - backup
+        - full
+        - incremental
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -55,5 +63,5 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/restore.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
 

--- a/aws/arcgis-enterprise-base-windows/README.md
+++ b/aws/arcgis-enterprise-base-windows/README.md
@@ -125,7 +125,7 @@ Instructions:
 3. Commit the changes to the Git branch and push the branch to GitHub.
 4. Run enterprise-base-windows-aws-backup workflow using the branch.
 
-> To meet the required recovery point objective (RPO), schedule runs of enterprise-base-windows-aws-backup workflow by configuring 'schedule' event in enterprise-base-windows-aws-backup.yaml file.
+> To meet the required recovery point objective (RPO), schedule runs of enterprise-base-windows-aws-backup workflow by configuring 'schedule' event in enterprise-base-windows-aws-backup.yaml file. When the backup workflow is triggered manually, the backup-restore mode is specified by the workflow inputs. However, when the workflow is triggered on schedule, the backup-restore mode is retrieved from the backup.tfvars.json config file. Note that scheduled workflows run on the latest commit on the `main` (or default) branch.
 
 > Base ArcGIS Enterprise deployments in a site use the same S3 bucket for backups. Run backups only for the active deployment branch.
 

--- a/aws/arcgis-enterprise-base-windows/infrastructure/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/variables.tf
@@ -164,7 +164,7 @@ variable "fileserver_volume_iops" {
   default     = 3000
 
   validation {
-    condition     = var.fileserver_volume_iops >= 3000   && var.fileserver_volume_iops <= 16000
+    condition     = var.fileserver_volume_iops >= 3000 && var.fileserver_volume_iops <= 16000
     error_message = "The fileserver_volume_iops value must be between 3000 and 16000."
   }    
 }

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-backup.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-backup.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,16 @@ name: enterprise-base-windows-aws-backup
 
 on: 
   workflow_dispatch:
+    inputs:
+      backup_restore_mode:
+        description: 'Type of backup'
+        type: choice
+        options:
+        - backup
+        - full
+        - incremental
   # schedule:
-  #   - cron: '0 0 * * *'
+  # - cron: '0 0 * * *'
       
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -57,4 +65,8 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/backup.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        if [ ${{ github.event.inputs.backup_restore_mode }} != "" ]; then
+          terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
+        else 
+          terraform apply -var-file $CONFIG_FILE -auto-approve
+        fi

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-restore.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-restore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,14 @@ name: enterprise-base-windows-aws-restore
 
 on: 
   workflow_dispatch:
+    inputs:
+      backup_restore_mode:
+        description: 'Type of backup'
+        type: choice
+        options:
+        - backup
+        - full
+        - incremental
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -55,5 +63,4 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/restore.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
-
+        terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve

--- a/config/aws/arcgis-enterprise-base-linux/restore.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/restore.tfvars.json
@@ -1,7 +1,6 @@
 {
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
-  "backup_restore_mode": "backup",
   "deployment_id": "arcgis-enterprise-base",
   "execution_timeout": 36000,
   "portal_admin_url": "https://localhost:7443/arcgis",

--- a/config/aws/arcgis-enterprise-base-windows/restore.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/restore.tfvars.json
@@ -1,7 +1,6 @@
 {
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
-  "backup_restore_mode": "backup",
   "deployment_id": "arcgis-enterprise-base",
   "execution_timeout": 36000,
   "portal_admin_url": "https://localhost:7443/arcgis",


### PR DESCRIPTION
The PR adds backup_restore_mode input to enterprise-base-linux-aws-backup, enterprise-base-linux-aws-restore,  enterprise-base-windows-aws-backup, and enterprise-base-windows-aws-restore workflows.

When the backup workflows are triggered manually, the backup-restore mode is specified by the workflow inputs. However, when the workflows are triggered on schedule, the backup-restore mode is retrieved from the backup.tfvars.json config file.

The restore workflows do not support scheduled executions and always get the backup-restore mode from the workflow inputs.