### PR TITLE
#186 Preserve private IPs of deployments EC2 instances

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -179,20 +179,11 @@ To activate the failover deployment:
 
 > Don't backup failover deployment until it is activated.
 
-### Create Snapshots and Restore from Snapshots (EXPERIMENTAL)
+### Create Snapshots and Restore from Snapshots
 
-GitHub Actions workflow **enterprise-base-linux-aws-snapshot** creates a system-level backup by creating AMIs from all EC2 instances of base ArcGIS Enterprise deployment. The workflow the workflow retrieves site and deployment IDs from [image.vars.json](../../config/aws/arcgis-enterprise-base-linux/image.vars.json) config file and runs snapshot_deployment Python script.
+GitHub Actions workflow **enterprise-base-linux-aws-snapshot** creates a system-level backup by creating AMIs from all EC2 instances of base ArcGIS Enterprise deployment. The workflow the workflow retrieves site and deployment IDs from [image.vars.json](../../config/aws/arcgis-enterprise-base-linux/image.vars.json) config file and runs snapshot_deployment Python script. The workflow requires ArcGISEnterpriseImage IAM policy.
 
 The workflows overwrites the AMI IDs in SSM Parameter Store written there by enterprise-base-linux-aws-image workflow. When necessary, the deployment can be rolled back to state captured in the snapshot by running enterprise-base-linux-aws-infrastructure workflow.
-
-Note that enterprise-base-linux-aws-infrastructure workflow run will replace the EC2 instances with new ones, so the deployment will be rolled back to the state captured in the snapshot, but the new EC2 instances will have new private IP addresses. To complete the rollback:
-
-1. Update /etc/hosts file on the primary and standby EC2 instances to use the new private IP addresses instead of the old ones.
-2. Update /opt/arcgis/portal/usr/arcgisportal/db/pg_hba.conf file on the primary and standby EC2 instances to use the new private IP addresses.
-3. Update /gisdata/arcgisdatastore/pgdata/pg_hba.conf file on the primary and standby EC2 instances to use the new private IP addresses.
-4. Restart arcgisserver, arcgisportal, and arcgisdatastore services on the primary and standby EC2 instances.
-
-> Alternatively, to prevent changing the IP addresses, the private IP addresses of the deployment's primary and standby could be fixed. Currently, the IP addresses cannot be configured in the config files. Achieving this requires updating the "infrastructure" Terraform template by adding "private_ip" property to aws_instance.primary and aws_instance.standby resources.
 
 > Running enterprise-base-linux-aws-snapshot workflow causes a short downtime because it reboots the EC2 instances.
 

--- a/aws/arcgis-enterprise-base-linux/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/README.md
@@ -105,6 +105,8 @@ The module uses the following SSM parameters:
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_network_interface.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
+| [aws_network_interface.standby](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_route53_record.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.standby](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
@@ -102,7 +102,7 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  
+
   default_tags {
     tags = {
       ArcGISSiteId       = var.site_id
@@ -139,7 +139,7 @@ locals {
 }
 
 module "site_core_info" {
-  source = "../../modules/site_core_info"
+  source  = "../../modules/site_core_info"
   site_id = var.site_id
 }
 
@@ -196,16 +196,28 @@ module "efs_mount" {
   ]
 }
 
+resource "aws_network_interface" "primary" {
+  subnet_id = local.primary_subnet
+  # private_ips    = ["10.0.64.XXX"]  
+  security_groups = [module.security_group.id]
+
+  tags = {
+    Name = "${var.site_id}/${var.deployment_id}/primary"
+  }
+}
+
 # Create primary EC2 instance
 resource "aws_instance" "primary" {
-  ami                    = nonsensitive(data.aws_ssm_parameter.primary_ami.value)
-  subnet_id              = local.primary_subnet
-  # private_ip             = "10.0.64.XXX"
-  vpc_security_group_ids = [module.security_group.id]
-  instance_type          = var.instance_type
-  key_name               = var.key_name
-  iam_instance_profile   = module.site_core_info.instance_profile_name
-  monitoring             = true
+  ami                  = nonsensitive(data.aws_ssm_parameter.primary_ami.value)
+  instance_type        = var.instance_type
+  key_name             = var.key_name
+  iam_instance_profile = module.site_core_info.instance_profile_name
+  monitoring           = true
+
+  network_interface {
+    network_interface_id = aws_network_interface.primary.id
+    device_index         = 0
+  }
 
   metadata_options {
     http_endpoint = "enabled"
@@ -235,16 +247,28 @@ resource "aws_instance" "primary" {
   }
 }
 
+resource "aws_network_interface" "standby" {
+  subnet_id = local.standby_subnet
+  # private_ips    = ["10.0.65.XXX"]  
+  security_groups = [module.security_group.id]
+
+  tags = {
+    Name = "${var.site_id}/${var.deployment_id}/standby"
+  }
+}
+
 # Create standby EC2 instance
 resource "aws_instance" "standby" {
-  ami                    = nonsensitive(data.aws_ssm_parameter.standby_ami.value)
-  subnet_id              = local.standby_subnet
-  # private_ip             = "10.0.65.XXX"
-  vpc_security_group_ids = [module.security_group.id]
-  instance_type          = var.instance_type
-  key_name               = var.key_name
-  iam_instance_profile   = module.site_core_info.instance_profile_name
-  monitoring             = true
+  ami                  = nonsensitive(data.aws_ssm_parameter.standby_ami.value)
+  instance_type        = var.instance_type
+  key_name             = var.key_name
+  iam_instance_profile = module.site_core_info.instance_profile_name
+  monitoring           = true
+
+  network_interface {
+    network_interface_id = aws_network_interface.standby.id
+    device_index         = 0
+  }
 
   metadata_options {
     http_endpoint = "enabled"

--- a/aws/arcgis-enterprise-base-windows/README.md
+++ b/aws/arcgis-enterprise-base-windows/README.md
@@ -177,18 +177,11 @@ To activate the failover deployment:
 
 > Don't backup failover deployment until it is activated.
 
-### Create Snapshots and Restore from Snapshots (EXPERIMENTAL)
+### Create Snapshots and Restore from Snapshots
 
-GitHub Actions workflow **enterprise-base-windows-aws-snapshot** creates a system-level backup by creating AMIs from all EC2 instances of base ArcGIS Enterprise deployment. The workflow retrieves site and deployment IDs from [image.vars.json](../../config/aws/arcgis-enterprise-base-windows/image.vars.json) config file and runs snapshot_deployment Python script.
+GitHub Actions workflow **enterprise-base-windows-aws-snapshot** creates a system-level backup by creating AMIs from all EC2 instances of base ArcGIS Enterprise deployment. The workflow retrieves site and deployment IDs from [image.vars.json](../../config/aws/arcgis-enterprise-base-windows/image.vars.json) config file and runs snapshot_deployment Python script. The workflow requires ArcGISEnterpriseImage IAM policy.
 
 The workflows overwrites the AMI IDs in SSM Parameter Store written there by enterprise-base-windows-aws-image workflow. When necessary, the deployment can be rolled back to state captured in the snapshot by running enterprise-base-windows-aws-infrastructure workflow.
-
-Note that enterprise-base-windows-aws-infrastructure workflow run will replace the EC2 instances with new ones, so the deployment will be rolled back to the state captured in the snapshot, but the new EC2 instances will have new private IP addresses. To complete the rollback:
-
-1. Update C:\Windows\System32\drivers\etc\hosts file on the primary and standby EC2 instances to use the new private IP addresses instead of the old ones.
-2. Update C:\arcgisportal\db\pg_hba.conf file on the primary and standby EC2 instances to use the new private IP addresses.
-3. Update C:\arcgisdatastore\pgdata\pg_hba.conf file on the primary and standby EC2 instances to use the new private IP addresses.
-4. Restart ArcGIS Server, Portal For ArcGIS, and ArcGIS Data Store windows services on the primary and standby EC2 instances.
 
 > Alternatively, to prevent changing the IP addresses, the private IP addresses of the deployment's primary and standby could be fixed. Currently, the IP addresses cannot be configured in the config files. Achieving this requires updating the "infrastructure" Terraform template by adding "private_ip" property to aws_instance.primary and aws_instance.standby resources.
 

--- a/aws/arcgis-enterprise-base-windows/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/README.md
@@ -101,6 +101,9 @@ The module uses the following SSM parameters:
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_network_interface.fileserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
+| [aws_network_interface.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
+| [aws_network_interface.standby](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_route53_record.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.fileserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -181,6 +181,20 @@ To activate the failover deployment:
 
 > Don't backup failover deployment until it is activated.
 
+### Create Snapshots and Restore from Snapshots
+
+GitHub Actions workflow **server-linux-aws-snapshot** creates a system-level backup by creating AMIs from EC2 instances of ArcGIS Server deployment. The workflow the workflow retrieves site and deployment IDs from [image.vars.json](../../config/aws/arcgis-server-linux/image.vars.json) config file and runs snapshot_deployment Python script. The workflow requires ArcGISEnterpriseImage IAM policy.
+
+The workflows overwrites the AMI IDs in SSM Parameter Store written there by server-linux-aws-image workflow. When necessary, the deployment can be rolled back to state captured in the snapshot by running server-linux-aws-infrastructure workflow.
+
+> Running server-linux-aws-snapshot workflow causes a short downtime because it reboots the EC2 instances.
+
+> The snapshot captures only the data on the EC2 instances that does not include the content of other storage services, such as EFS filesystems used by ArcGIS Server config store.
+
+Since creating snapshots involves downtime and integrity of the data cannot be guaranteed if data in the storage services was updated after the snapshot creation, snapshots are not recommended for use as backups for active deployments. Snapshots should be created during planned downtime, after deactivating the deployment, and before applying system and application patches or other system-level updates.
+
+> The snapshot creation time depends on the size and throughput of the root EBS volumes of the EC2 instances.
+
 ## In-Place Updates and Upgrades
 
 GitHub Actions workflow server-linux-aws-application supports upgrade mode used to in-place patch or upgrade the ArcGIS Server applications on the EC2 instances. In the upgrade mode, the workflow copies the required patches and setups to the private repository S3 bucket and downloads them to the EC2 instances. If the ArcGIS Server version was changed, it installs the new version of ArcGIS Server and re-configures it.

--- a/aws/iam-policies/ArcGISEnterpriseDestroy.json
+++ b/aws/iam-policies/ArcGISEnterpriseDestroy.json
@@ -20,9 +20,11 @@
         {
             "Effect": "Allow",
             "Action": [
+                "ec2:DeleteNetworkInterface",
                 "ec2:DeleteSecurityGroup",
                 "ec2:DeleteTags",
                 "ec2:DeleteVolume",
+                "ec2:DetachNetworkInterface",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:TerminateInstances"

--- a/aws/iam-policies/ArcGISEnterpriseInfrastructure.json
+++ b/aws/iam-policies/ArcGISEnterpriseInfrastructure.json
@@ -13,6 +13,7 @@
         {
             "Effect": "Allow",
             "Action": [
+                "ec2:CreateNetworkInterface",
                 "ec2:CreateSecurityGroup",
                 "ec2:CreateTags",
                 "ec2:CreateVolume",
@@ -20,6 +21,7 @@
                 "ec2:DescribeInstanceAttribute",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
+                "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeSecurityGroupReferences",
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSecurityGroups",
@@ -37,6 +39,8 @@
                 "ec2:AttachVolume",
                 "ec2:AuthorizeSecurityGroupEgress",
                 "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:DetachNetworkInterface",
+                "ec2:DeleteNetworkInterface",
                 "ec2:ModifyInstanceAttribute",
                 "ec2:ModifySecurityGroupRules",
                 "ec2:ModifyVolume",


### PR DESCRIPTION
The PR changes enterprise-base-linux-aws-infrastructure and enterprise-base-windows-aws-infrastructure workflows to create network interfaces separately from the EC2 instances to prevent the network interfaces from being replaced when the EC2 instances are replaced. 