### PR TITLE
#176 Allow 11.3 for arcgis_version in base enterprise templates

### DIFF
--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -78,8 +78,8 @@ variable "arcgis_version" {
   default     = "11.4"
 
   validation {
-    condition     = contains(["11.4"], var.arcgis_version)
-    error_message = "Valid values for arcgis_version variable are 11.4."
+    condition     = contains(["11.3", "11.4"], var.arcgis_version)
+    error_message = "Valid values for arcgis_version variable are 11.3 and 11.4."
   }
 }
 

--- a/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
@@ -86,8 +86,8 @@ variable "arcgis_version" {
   default     = "11.4"
 
   validation {
-    condition     = contains(["11.4"], var.arcgis_version)
-    error_message = "Valid values for arcgis_version variable are 11.4."
+    condition     = contains(["11.3", "11.4"], var.arcgis_version)
+    error_message = "Valid values for arcgis_version variable are 11.3 and 11.4."
   }
 }
 

--- a/aws/arcgis-enterprise-base-windows/application/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/application/variables.tf
@@ -73,8 +73,8 @@ variable "arcgis_version" {
   default     = "11.4"
 
   validation {
-    condition     = contains(["11.4"], var.arcgis_version)
-    error_message = "Valid values for arcgis_version variable are 11.4."
+    condition     = contains(["11.3", "11.4"], var.arcgis_version)
+    error_message = "Valid values for arcgis_version variable are 11.3 and 11.4."
   }
 }
 

--- a/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
@@ -86,8 +86,8 @@ variable "arcgis_version" {
   default     = "11.4"
 
   validation {
-    condition     = contains(["11.4"], var.arcgis_version)
-    error_message = "Valid values for arcgis_version variable are 11.4."
+    condition     = contains(["11.3", "11.4"], var.arcgis_version)
+    error_message = "Valid values for arcgis_version variable are 11.3 and 11.4."
   }
 }
 


### PR DESCRIPTION
This PR adds back 11.3 to the list of allowed ArcGIS Enterprise versions in arcgis-version input parameter validation.

11.3 was added back just to test base ArcGIS Enterprise upgrade. 11.3 is not actually supported by the templates because it does not support object store in S3 configured by the templates. It will be removed before version 0.3.0 of the templates is released. 