### PR TITLE
#202 Support triggers other than workflow_dispatch in all workflows

### DIFF
--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-infrastructure.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-infrastructure.yaml
@@ -64,7 +64,7 @@ jobs:
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
     - name: Terraform Apply
       id: apply
-      if: github.event.inputs.terraform_command == 'apply'
+      if: github.event.inputs.terraform_command != 'plan'
       run: terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Plan
       id: plan

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-infrastructure.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-infrastructure.yaml
@@ -64,7 +64,7 @@ jobs:
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
     - name: Terraform Apply
       id: apply
-      if: github.event.inputs.terraform_command == 'apply'
+      if: github.event.inputs.terraform_command != 'plan'
       run: terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Plan
       id: plan

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-infrastructure.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-infrastructure.yaml
@@ -69,7 +69,7 @@ jobs:
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
     - name: Terraform Apply
       id: apply
-      if: github.event.inputs.terraform_command == 'apply'
+      if: github.event.inputs.terraform_command != 'plan'
       run: terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Plan
       id: plan

--- a/aws/arcgis-site-core/workflows/site-automation-chef-aws.yaml
+++ b/aws/arcgis-site-core/workflows/site-automation-chef-aws.yaml
@@ -61,7 +61,7 @@ jobs:
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/automation-chef.tfstate" -backend-config="region=$TF_VAR_aws_region" 
     - name: Terraform Apply
       id: terraform-apply
-      if: github.event.inputs.terraform_command == 'apply'
+      if: github.event.inputs.terraform_command != 'plan'
       run: terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Plan
       id: terraform-plan

--- a/aws/arcgis-site-core/workflows/site-core-aws.yaml
+++ b/aws/arcgis-site-core/workflows/site-core-aws.yaml
@@ -59,7 +59,7 @@ jobs:
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/infrastructure-core.tfstate" -backend-config="region=$TF_VAR_aws_region" 
     - name: Terraform Apply
       id: terraform-apply
-      if: github.event.inputs.terraform_command == 'apply'
+      if: github.event.inputs.terraform_command != 'plan'
       run: terraform apply -var-file $CONFIG_FILE -auto-approve
     - name: Terraform Plan
       id: terraform-plan

--- a/aws/arcgis-site-core/workflows/site-k8s-cluster-aws.yaml
+++ b/aws/arcgis-site-core/workflows/site-k8s-cluster-aws.yaml
@@ -66,11 +66,11 @@ jobs:
       run: terraform plan -var-file $CONFIG_FILE
     - name: Terraform Apply
       id: apply
-      if: github.event.inputs.terraform_command == 'apply'
+      if: github.event.inputs.terraform_command != 'plan'
       run: terraform apply -var-file $CONFIG_FILE -var=container_registry_user=$CONTAINER_REGISTRY_USER -var=container_registry_password=$CONTAINER_REGISTRY_PASSWORD -auto-approve
     - name: Test EKS cluster access
       id: test
-      if: github.event.inputs.terraform_command == 'apply'      
+      if: github.event.inputs.terraform_command != 'plan'      
       run: |
         echo "Test"
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)

--- a/azure/arcgis-site-core/workflows/site-core-azure.yaml
+++ b/azure/arcgis-site-core/workflows/site-core-azure.yaml
@@ -63,7 +63,7 @@ jobs:
                          -backend-config="key=$SITE_ID/azure/infrastructure-core.tfstate"
       - name: Terraform Apply
         id: terraform-apply
-        if: github.event.inputs.terraform_command == 'apply'
+        if: github.event.inputs.terraform_command != 'plan'
         run: terraform apply -var-file $CONFIG_FILE -auto-approve
       - name: Terraform Plan
         id: terraform-plan

--- a/azure/arcgis-site-core/workflows/site-k8s-cluster-azure.yaml
+++ b/azure/arcgis-site-core/workflows/site-k8s-cluster-azure.yaml
@@ -63,7 +63,7 @@ jobs:
                          -backend-config="container_name=$TERRAFORM_BACKEND_CONTAINER_NAME" \
                          -backend-config="key=$SITE_ID/azure/k8s-cluster.tfstate"
       - name: Terraform Apply
-        if: github.event.inputs.terraform_command == 'apply'
+        if: github.event.inputs.terraform_command != 'plan'
         run: |
           az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
           az account set --subscription $ARM_SUBSCRIPTION_ID
@@ -72,7 +72,7 @@ jobs:
         if: github.event.inputs.terraform_command == 'plan'
         run: terraform plan -var-file $CONFIG_FILE -var=container_registry_user=$CONTAINER_REGISTRY_USER -var=container_registry_password=$CONTAINER_REGISTRY_PASSWORD
       - name: Test AKS cluster access
-        if: github.event.inputs.terraform_command == 'apply'
+        if: github.event.inputs.terraform_command != 'plan'
         run: |
           echo "Test"
           SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)


### PR DESCRIPTION
The fix changes the conditions in the workflows to run Terraform apply if `github.event.inputs.terraform_command != 'plan'` instead of `github.event.inputs.terraform_command == 'apply'`.