### PR TITLE
#205 Save ALB DNS names in SSM parameters

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -68,7 +68,7 @@ Instructions:
 6. Run enterprise-base-linux-aws-infrastructure workflow using the branch.
 7. Retrieve the DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the base ArcGIS Enterprise domain name.
 
-> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the outputs, check the run logs of "Terraform Apply" step.
+> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the DNS name, check the run logs of "Terraform Apply" step or read it from "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter.
 
 > When updating the infrastructure, first run the workflow with terraform_command=plan before running it with terraform_command=apply and check the logs to make sure that Terraform does not destroy and recreate critical AWS resources such as EC2 instances.
 

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -42,7 +42,7 @@ My Esri user name and password must be specified either using environment variab
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/application/main.tf
+++ b/aws/arcgis-enterprise-base-linux/application/main.tf
@@ -42,7 +42,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/backup/README.md
+++ b/aws/arcgis-enterprise-base-linux/backup/README.md
@@ -18,7 +18,7 @@ On the machine where Terraform is executed:
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/backup/main.tf
+++ b/aws/arcgis-enterprise-base-linux/backup/main.tf
@@ -18,7 +18,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/README.md
@@ -54,7 +54,7 @@ The SSM commands output stored in the logs S3 bucket is copied in the Terraform 
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
@@ -66,7 +66,7 @@ The module uses the following SSM parameters:
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
 | /arcgis/${var.site_id}/vpc/id | VPC Id |
 
-The module creates the following SSM parameters:
+The module writes the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/README.md
@@ -66,6 +66,18 @@ The module uses the following SSM parameters:
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
 | /arcgis/${var.site_id}/vpc/id | VPC Id |
 
+The module creates the following SSM parameters:
+
+| SSM parameter name | Description |
+|--------------------|-------------|
+| /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group Id |
+| /arcgis/${var.site_id}/${var.deployment_id}/sns-topic-arn | ARN of SNS topic for deployment alarms |
+| /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | Portal for ArcGIS content store S3 bucket |
+| /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | Object store S3 bucket |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/arn | ARN of the application load balancer (if alb_deployment_id is not specified) |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name | DNS name of the application load balancer (if alb_deployment_id is not specified) |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/security-group-id | Security group Id of the application load balancer (if alb_deployment_id is not specified) |
+
 ## Providers
 
 | Name | Version |

--- a/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
@@ -54,7 +54,7 @@
  * 
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
@@ -66,7 +66,7 @@
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
  * | /arcgis/${var.site_id}/vpc/id | VPC Id |
  *
- * The module creates the following SSM parameters:
+ * The module writes the following SSM parameters:
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
@@ -65,6 +65,18 @@
  * | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
  * | /arcgis/${var.site_id}/vpc/id | VPC Id |
+ *
+ * The module creates the following SSM parameters:
+ *
+ * | SSM parameter name | Description |
+ * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group Id |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/sns-topic-arn | ARN of SNS topic for deployment alarms |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | Portal for ArcGIS content store S3 bucket |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | Object store S3 bucket |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/arn | ARN of the application load balancer (if alb_deployment_id is not specified) |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name | DNS name of the application load balancer (if alb_deployment_id is not specified) |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/security-group-id | Security group Id of the application load balancer (if alb_deployment_id is not specified) |
  */
 
 # Copyright 2024-2025 Esri

--- a/aws/arcgis-enterprise-base-linux/restore/README.md
+++ b/aws/arcgis-enterprise-base-linux/restore/README.md
@@ -19,7 +19,7 @@ On the machine where Terraform is executed:
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-linux/restore/main.tf
+++ b/aws/arcgis-enterprise-base-linux/restore/main.tf
@@ -19,7 +19,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/README.md
+++ b/aws/arcgis-enterprise-base-windows/README.md
@@ -69,7 +69,7 @@ Instructions:
 6. Run enterprise-base-windows-aws-infrastructure workflow using the branch.
 7. Retrieve the DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the base ArcGIS Enterprise domain name.
 
-> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the outputs check the run logs of "Terraform Apply" step.
+> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the DNS name, check the run logs of "Terraform Apply" step or read it from "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter.
 
 > When updating the infrastructure, first run the workflow with terraform_command=plan before running it with terraform_command=apply and check the logs to make sure that Terraform does not destroy and recreate critical AWS resources such as EC2 instances.
 

--- a/aws/arcgis-enterprise-base-windows/application/README.md
+++ b/aws/arcgis-enterprise-base-windows/application/README.md
@@ -42,7 +42,7 @@ My Esri user name and password must be specified either using environment variab
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/application/main.tf
+++ b/aws/arcgis-enterprise-base-windows/application/main.tf
@@ -42,7 +42,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/backup/README.md
+++ b/aws/arcgis-enterprise-base-windows/backup/README.md
@@ -17,7 +17,7 @@ On the machine where Terraform is executed:
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/backup/main.tf
+++ b/aws/arcgis-enterprise-base-windows/backup/main.tf
@@ -17,7 +17,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/README.md
@@ -52,7 +52,7 @@ The SSM commands output stored in the logs S3 bucket is copied in the Terraform 
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
@@ -65,7 +65,7 @@ The module uses the following SSM parameters:
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
 | /arcgis/${var.site_id}/vpc/id | VPC Id |
 
-The module creates the following SSM parameters:
+The module writes the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/README.md
@@ -65,6 +65,18 @@ The module uses the following SSM parameters:
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
 | /arcgis/${var.site_id}/vpc/id | VPC Id |
 
+The module creates the following SSM parameters:
+
+| SSM parameter name | Description |
+|--------------------|-------------|
+| /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group Id |
+| /arcgis/${var.site_id}/${var.deployment_id}/sns-topic-arn | ARN of SNS topic for deployment alarms |
+| /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | Portal for ArcGIS content store S3 bucket |
+| /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | Object store S3 bucket |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/arn | ARN of the application load balancer (if alb_deployment_id is not specified) |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name | DNS name of the application load balancer (if alb_deployment_id is not specified) |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/security-group-id | Security group Id of the application load balancer (if alb_deployment_id is not specified) |
+
 ## Providers
 
 | Name | Version |

--- a/aws/arcgis-enterprise-base-windows/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/main.tf
@@ -64,6 +64,18 @@
  * | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
  * | /arcgis/${var.site_id}/vpc/id | VPC Id |
+ *
+ * The module creates the following SSM parameters:
+ *
+ * | SSM parameter name | Description |
+ * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group Id |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/sns-topic-arn | ARN of SNS topic for deployment alarms |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | Portal for ArcGIS content store S3 bucket |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | Object store S3 bucket |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/arn | ARN of the application load balancer (if alb_deployment_id is not specified) |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name | DNS name of the application load balancer (if alb_deployment_id is not specified) |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/security-group-id | Security group Id of the application load balancer (if alb_deployment_id is not specified) |
  */
 
 # Copyright 2024-2025 Esri

--- a/aws/arcgis-enterprise-base-windows/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/main.tf
@@ -52,7 +52,7 @@
  * 
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
@@ -65,7 +65,7 @@
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
  * | /arcgis/${var.site_id}/vpc/id | VPC Id |
  *
- * The module creates the following SSM parameters:
+ * The module writes the following SSM parameters:
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/restore/README.md
+++ b/aws/arcgis-enterprise-base-windows/restore/README.md
@@ -19,7 +19,7 @@ On the machine where Terraform is executed:
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-enterprise-base-windows/restore/main.tf
+++ b/aws/arcgis-enterprise-base-windows/restore/main.tf
@@ -19,7 +19,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-enterprise-k8s/README.md
+++ b/aws/arcgis-enterprise-k8s/README.md
@@ -69,7 +69,7 @@ Instructions:
 5. Run enterprise-k8s-aws-ingress workflow using the branch.
 6. If "hosted_zone_id" property was not specified, retrieve DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the ArcGIS Enterprise domain name.
 
-> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the outputs, check the run logs of "Run Terraform" step.
+> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the DNS name, check the run logs of "Terraform Apply" step or read it from "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter.
 
 > See [Elastic Load Balancing SSL negotiation configuration](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for the list of SSL policies.
 

--- a/aws/arcgis-enterprise-k8s/ingress/README.md
+++ b/aws/arcgis-enterprise-k8s/ingress/README.md
@@ -8,7 +8,8 @@ a cluster-level ingress controller that routes traffic to the deployment.
 See: https://enterprise-k8s.arcgis.com/en/latest/deploy/use-a-cluster-level-ingress-controller-with-eks.htm
 
 If a Route 53 hosted zone ID is provided, a CNAME record is created in the hosted zone
-that points the deployment's FQDN to the load balancer's DNS name.
+that points the deployment's FQDN to the load balancer's DNS name. The DNS name is also stored in
+"/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter.
 
 ## Requirements
 
@@ -29,6 +30,7 @@ On the machine where Terraform is executed:
 | Name | Type |
 |------|------|
 | [aws_route53_record.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_ssm_parameter.alb_dns_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [kubernetes_ingress_v1.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) | resource |
 | [kubernetes_namespace.arcgis_enterprise](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 
@@ -50,5 +52,5 @@ On the machine where Terraform is executed:
 
 | Name | Description |
 |------|-------------|
-| alb_dns_name | DNS name of the load balancer |
+| alb_dns_name | DNS name of the deployment's ingress load balancer |
 <!-- END_TF_DOCS -->

--- a/aws/arcgis-enterprise-k8s/ingress/main.tf
+++ b/aws/arcgis-enterprise-k8s/ingress/main.tf
@@ -8,7 +8,8 @@
  * See: https://enterprise-k8s.arcgis.com/en/latest/deploy/use-a-cluster-level-ingress-controller-with-eks.htm
  *
  * If a Route 53 hosted zone ID is provided, a CNAME record is created in the hosted zone
- * that points the deployment's FQDN to the load balancer's DNS name.
+ * that points the deployment's FQDN to the load balancer's DNS name. The DNS name is also stored in 
+ * "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter.
  * 
  * ## Requirements
  * 
@@ -119,6 +120,13 @@ resource "kubernetes_ingress_v1" "arcgis_enterprise" {
   depends_on = [
     kubernetes_namespace.arcgis_enterprise
   ]
+}
+
+resource "aws_ssm_parameter" "alb_dns_name" {
+  name        = "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name"
+  type        = "String"
+  value       = kubernetes_ingress_v1.arcgis_enterprise.status.0.load_balancer.0.ingress.0.hostname
+  description = "DNS name of the deployment's ingress load balancer"
 }
 
 resource "aws_route53_record" "arcgis_enterprise" {

--- a/aws/arcgis-enterprise-k8s/ingress/outputs.tf
+++ b/aws/arcgis-enterprise-k8s/ingress/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
  
 output "alb_dns_name" {
-  description = "DNS name of the load balancer"
+  description = "DNS name of the deployment's ingress load balancer"
   value = kubernetes_ingress_v1.arcgis_enterprise.status.0.load_balancer.0.ingress.0.hostname
 }

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -69,7 +69,7 @@ Instructions:
 7. Run server-linux-aws-infrastructure workflow using the branch.
 8. If alb_deployment_id is not set, retrieve the DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the ArcGIS Server domain name.
 
-> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the outputs, check the run logs of "Terraform Apply" step.
+> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the DNS name, check the run logs of "Terraform Apply" step or read it from "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter.
 
 > When updating the infrastructure, first run the workflow with terraform_command=plan before running it with terraform_command=apply and check the logs to make sure that Terraform does not destroy and recreate critical AWS resources such as EC2 instances.
 

--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -41,7 +41,7 @@ My Esri user name and password must be specified either using environment variab
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-server-linux/application/main.tf
+++ b/aws/arcgis-server-linux/application/main.tf
@@ -41,7 +41,7 @@
  *
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/arcgis-server-linux/infrastructure/README.md
+++ b/aws/arcgis-server-linux/infrastructure/README.md
@@ -62,7 +62,7 @@ The module uses the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
-| /arcgis/${var.site_id}/${var.alb_deployment_id}/alb/arn | LBB ARN (if alb_deployment_id is specified) |
+| /arcgis/${var.site_id}/${var.alb_deployment_id}/alb/arn | ALB ARN (if alb_deployment_id is specified) |
 | /arcgis/${var.site_id}/${var.alb_deployment_id}/alb/security-group-id | ALB security group Id (if alb_deployment_id is specified) |
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI Id |
@@ -71,6 +71,16 @@ The module uses the following SSM parameters:
 | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
 | /arcgis/${var.site_id}/vpc/id | VPC Id |
+
+The module creates the following SSM parameters:
+
+| SSM parameter name | Description |
+|--------------------|-------------|
+| /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group Id |
+| /arcgis/${var.site_id}/${var.deployment_id}/sns-topic-arn | ARN of SNS topic for deployment alarms |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/arn | ARN of the application load balancer (if alb_deployment_id is not specified) |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name | DNS name of the application load balancer (if alb_deployment_id is not specified) |
+| /arcgis/${var.site_id}/${var.deployment_id}/alb/security-group-id | Security group Id of the application load balancer (if alb_deployment_id is not specified) |
 
 ## Providers
 

--- a/aws/arcgis-server-linux/infrastructure/README.md
+++ b/aws/arcgis-server-linux/infrastructure/README.md
@@ -58,7 +58,7 @@ The SSM commands output stored in the logs S3 bucket is copied in the Terraform 
 
 ## SSM Parameters
 
-The module uses the following SSM parameters:
+The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
@@ -72,7 +72,7 @@ The module uses the following SSM parameters:
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
 | /arcgis/${var.site_id}/vpc/id | VPC Id |
 
-The module creates the following SSM parameters:
+The module writes the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|

--- a/aws/arcgis-server-linux/infrastructure/ingress.tf
+++ b/aws/arcgis-server-linux/infrastructure/ingress.tf
@@ -97,4 +97,3 @@ module "private_server_https_alb_target" {
     module.alb
   ]
 }
-

--- a/aws/arcgis-server-linux/infrastructure/main.tf
+++ b/aws/arcgis-server-linux/infrastructure/main.tf
@@ -62,7 +62,7 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
- * | /arcgis/${var.site_id}/${var.alb_deployment_id}/alb/arn | LBB ARN (if alb_deployment_id is specified) |
+ * | /arcgis/${var.site_id}/${var.alb_deployment_id}/alb/arn | ALB ARN (if alb_deployment_id is specified) |
  * | /arcgis/${var.site_id}/${var.alb_deployment_id}/alb/security-group-id | ALB security group Id (if alb_deployment_id is specified) |
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI Id |
@@ -71,6 +71,16 @@
  * | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
  * | /arcgis/${var.site_id}/vpc/id | VPC Id |
+ *
+ * The module creates the following SSM parameters:
+ *
+ * | SSM parameter name | Description |
+ * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group Id |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/sns-topic-arn | ARN of SNS topic for deployment alarms |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/arn | ARN of the application load balancer (if alb_deployment_id is not specified) |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name | DNS name of the application load balancer (if alb_deployment_id is not specified) |
+ * | /arcgis/${var.site_id}/${var.deployment_id}/alb/security-group-id | Security group Id of the application load balancer (if alb_deployment_id is not specified) |
  */
 
 # Copyright 2024-2025 Esri

--- a/aws/arcgis-server-linux/infrastructure/main.tf
+++ b/aws/arcgis-server-linux/infrastructure/main.tf
@@ -58,7 +58,7 @@
  * 
  * ## SSM Parameters
  *
- * The module uses the following SSM parameters: 
+ * The module reads the following SSM parameters: 
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
@@ -72,7 +72,7 @@
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone Id |
  * | /arcgis/${var.site_id}/vpc/id | VPC Id |
  *
- * The module creates the following SSM parameters:
+ * The module writes the following SSM parameters:
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|

--- a/aws/iam-policies/ArcGISEnterpriseK8s.json
+++ b/aws/iam-policies/ArcGISEnterpriseK8s.json
@@ -51,8 +51,14 @@
         },
         {
             "Effect": "Allow",
-            "Action":[
-                "ssm:GetParameter"
+            "Action": [
+                "ssm:AddTagsToResource",
+                "ssm:DeleteParameter",
+                "ssm:DescribeParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:ListTagsForResource",
+                "ssm:PutParameter"
             ],
             "Resource": "*"
         },

--- a/aws/modules/alb/README.md
+++ b/aws/modules/alb/README.md
@@ -3,9 +3,9 @@
 
 The module creates and configures Application Load Balancer for a deployment.
 It sets up a security group, HTTP and HTTPS listeners, and a default target group for the load balancer.
-if the hosted zone ID and domain name are provided, the module also creates Route 53 records for the load balancer.
+The module also creates a private Route53 hosted zone and an alias A record for the load balancer DNS name.
 The load balancer is configured to redirect HTTP ports to HTTPS.
-The security group Id and ARN of the load balancer are stored in SSM Parameter Store.
+The security group Id, ARN, and DNS name of the load balancer are stored in SSM Parameter Store.
 
 ## Providers
 
@@ -21,11 +21,13 @@ The security group Id and ARN of the load balancer are stored in SSM Parameter S
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_route53_record.arcgis_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_security_group.arcgis_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.allow_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.allow_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ssm_parameter.alb_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.alb_dns_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.alb_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 
 ## Inputs
@@ -33,9 +35,8 @@ The security group Id and ARN of the load balancer are stored in SSM Parameter S
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | client_cidr_blocks | Client CIDR blocks | `list(string)` | ```[ "0.0.0.0/0" ]``` | no |
-| deployment_fqdn | Fully qualified domain name of the ArcGIS Server deployment | `string` | `null` | no |
+| deployment_fqdn | Fully qualified domain name of the ArcGIS Server deployment | `string` | n/a | yes |
 | deployment_id | ArcGIS Server deployment Id | `string` | n/a | yes |
-| hosted_zone_id | The Route 53 hosted zone ID for the deployment FQDN | `string` | `null` | no |
 | http_ports | List of HTTP ports for the load balancer | `list(number)` | ```[ 80 ]``` | no |
 | https_ports | List of HTTPS ports for the load balancer | `list(number)` | ```[ 443 ]``` | no |
 | internal_load_balancer | If true, the load balancer scheme is set to 'internal' | `bool` | `false` | no |
@@ -51,5 +52,6 @@ The security group Id and ARN of the load balancer are stored in SSM Parameter S
 |------|-------------|
 | alb_arn | Application Load Balancer ARN |
 | alb_dns_name | Application Load Balancer DNS name |
+| alb_zone_id | Application Load Balancer zone ID |
 | security_group_id | Application Load Balancer security group Id |
 <!-- END_TF_DOCS -->

--- a/aws/modules/alb/main.tf
+++ b/aws/modules/alb/main.tf
@@ -5,7 +5,7 @@
  * It sets up a security group, HTTP and HTTPS listeners, and a default target group for the load balancer.
  * The module also creates a private Route53 hosted zone and an alias A record for the load balancer DNS name.
  * The load balancer is configured to redirect HTTP ports to HTTPS.
- * The security group Id and ARN of the load balancer are stored in SSM Parameter Store.
+ * The security group Id, ARN, and DNS name of the load balancer are stored in SSM Parameter Store.
  */
 
 # Copyright 2025 Esri
@@ -127,6 +127,13 @@ resource "aws_ssm_parameter" "alb_arn" {
   type        = "String"
   value       = aws_lb.alb.arn
   description = "ARN of the deployment's ALB"
+}
+
+resource "aws_ssm_parameter" "alb_dns_name" {
+  name        = "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name"
+  type        = "String"
+  value       = aws_lb.alb.dns_name
+  description = "DNS name of the deployment's ALB"
 }
 
 # Route53 private hosted zone for the deployment FQDN

--- a/azure/arcgis-enterprise-k8s/README.md
+++ b/azure/arcgis-enterprise-k8s/README.md
@@ -66,7 +66,7 @@ Instructions:
 6. Run enterprise-k8s-azure-ingress workflow using the branch.
 7. If Azure DNS is not used, retrieve DNS name of the load balancer created by the workflow and create a CNAME record for it within the DNS server of the ArcGIS Enterprise domain name.
 
-> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the outputs, check the run logs of "Run Terraform" step.
+> Job outputs are not shown in the properties of completed GitHub Actions run. To retrieve the DNS name, check the run logs of "Terraform Apply" step or read it from "${var.deployment_id}-alb-dns-name" secret of the site's key vault.
 
 ### 3. Create ArcGIS Enterprise Organization
 

--- a/azure/arcgis-enterprise-k8s/ingress/README.md
+++ b/azure/arcgis-enterprise-k8s/ingress/README.md
@@ -17,6 +17,7 @@ This module manages the ingress resources for the deployment of ArcGIS Enterpris
 
 If hosted zone name is provided, a CNAME record is created in the hosted zone
 that points the deployment's FQDN to the Application Gateway's frontend DNS name.
+The DNS name is also stored in "${var.deployment_id}-ingress-dns-name" Key Vault secret.
 
 ## Requirements
 
@@ -45,6 +46,7 @@ On the machine where Terraform is executed:
 |------|------|
 | [azurerm_application_load_balancer_frontend.deployment_frontend](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_load_balancer_frontend) | resource |
 | [azurerm_dns_cname_record.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record) | resource |
+| [azurerm_key_vault_secret.alb_dns_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [kubernetes_manifest.gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.health_check_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.http_route](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
@@ -72,6 +74,6 @@ On the machine where Terraform is executed:
 
 | Name | Description |
 |------|-------------|
-| alb_dns_name | FQDN of the Application Gateway frontend |
 | deployment_url | URL of the ArcGIS Enterprise on Kubernetes deployment |
+| alb_dns_name | FQDN of the Application Gateway frontend |
 <!-- END_TF_DOCS -->

--- a/azure/arcgis-enterprise-k8s/ingress/main.tf
+++ b/azure/arcgis-enterprise-k8s/ingress/main.tf
@@ -17,6 +17,7 @@
  *
  * If hosted zone name is provided, a CNAME record is created in the hosted zone
  * that points the deployment's FQDN to the Application Gateway's frontend DNS name.
+ * The DNS name is also stored in "${var.deployment_id}-alb-dns-name" Key Vault secret.
  * 
  * ## Requirements
  * 
@@ -293,6 +294,12 @@ resource "kubernetes_manifest" "health_check_policy" {
   depends_on = [
     kubernetes_namespace.arcgis_enterprise
   ]
+}
+
+resource "azurerm_key_vault_secret" "alb_dns_name" {
+  name         = "${var.deployment_id}-alb-dns-name"
+  value        = azurerm_application_load_balancer_frontend.deployment_frontend.fully_qualified_domain_name
+  key_vault_id = module.site_core_info.vault_id
 }
 
 # Create a CNAME record in the hosted zone that points the deployment's FQDN 

--- a/azure/arcgis-enterprise-k8s/ingress/outputs.tf
+++ b/azure/arcgis-enterprise-k8s/ingress/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Esri
+# Copyright 2024-2025 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The fix changes Terraform child module "alb" to save ALB DNS name in  "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter in addition to the ALB ARN and the ALB security group Id. The module is used by the "infrastructure" workflows of aws/arcgis-enterprise-base-linux, aws/arcgis-enterprise-base-windows, and aws/arcgis-server-linux templates.

The fix also changes and "ingress" workflow of aws/arcgis-enterprise-k8s template to save ALB DNS name in  "/arcgis/${var.site_id}/${var.deployment_id}/alb/dns-name" SSM parameter and the "ingress" workflow of azure/arcgis-enterprise-k8s template to save ALB DNS name in  "${var.deployment_id}-alb-dns-name" Key Vault secret.