### PR TITLE
#195 Updated ArcGISEnterpriseDestroy IAM policy

### DIFF
--- a/aws/iam-policies/ArcGISEnterpriseDestroy.json
+++ b/aws/iam-policies/ArcGISEnterpriseDestroy.json
@@ -176,6 +176,7 @@
         {
             "Effect": "Allow",
             "Action": [
+                "route53:DeleteHostedZone",
                 "route53:GetChange",
                 "route53:GetHostedZone",
                 "route53:ChangeResourceRecordSets",


### PR DESCRIPTION
Allow "route53:DeleteHostedZone" action in ArcGISEnterpriseDestroy IAM policy.