### PR TITLE
#209 Deregister deployments AMIs and delete EBS snapshots in *-aws-destroy workflows

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -182,7 +182,7 @@ Instructions:
 
 ## Destroying Deployments
 
-GitHub Actions workflow **enterprise-base-linux-aws-destroy** destroys AWS resources created by enterprise-base-linux-aws-infrastructure and enterprise-base-linux-aws-application workflows.
+GitHub Actions workflow **enterprise-base-linux-aws-destroy** destroys AWS resources created by enterprise-base-linux-aws-image, enterprise-base-linux-aws-snapshot, enterprise-base-linux-aws-infrastructure and enterprise-base-linux-aws-application workflows.
 
 The workflow uses [infrastructure](infrastructure/README.md) and [application](application/README.md) Terraform templates with [infrastructure.tfvars.json](../../config/aws/arcgis-enterprise-base-linux/infrastructure.tfvars.json) and [application.tfvars.json](../../config/aws/arcgis-enterprise-base-linux/application.tfvars.json) config files.
 

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
@@ -20,6 +20,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}  
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
@@ -63,3 +64,9 @@ jobs:
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
           terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+      - name: Delete AMIs
+        id: delete-amis
+        run: |
+          SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
+          DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
+          python -m delete_deployment_amis -s $SITE_ID -d $DEPLOYMENT_ID

--- a/aws/arcgis-enterprise-base-windows/README.md
+++ b/aws/arcgis-enterprise-base-windows/README.md
@@ -184,7 +184,7 @@ Instructions:
 
 ## Destroying Deployments
 
-GitHub Actions workflow **enterprise-base-windows-aws-destroy** destroys AWS resources created by enterprise-base-windows-aws-infrastructure and enterprise-base-windows-aws-application workflows.
+GitHub Actions workflow **enterprise-base-windows-aws-destroy** destroys AWS resources created by enterprise-base-windows-aws-image, enterprise-base-windows-aws-snapshot, enterprise-base-windows-aws-infrastructure and enterprise-base-windows-aws-application workflows.
 
 The workflow uses [infrastructure](infrastructure/README.md) and [application](application/README.md) Terraform templates with [infrastructure.tfvars.json](../../config/aws/arcgis-enterprise-base-windows/infrastructure.tfvars.json) and [application.tfvars.json](../../config/aws/arcgis-enterprise-base-windows/application.tfvars.json) config files.
 

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
@@ -20,6 +20,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}  
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
@@ -63,3 +64,9 @@ jobs:
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
         terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+    - name: Delete AMIs
+      id: delete-amis
+      run: |
+        SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
+        DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
+        python -m delete_deployment_amis -s $SITE_ID -d $DEPLOYMENT_ID

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -183,7 +183,7 @@ Instructions:
 
 ## Destroying Deployments
 
-GitHub Actions workflow **server-linux-aws-destroy** destroys AWS resources created by server-linux-aws-infrastructure and server-linux-aws-application workflows.
+GitHub Actions workflow **server-linux-aws-destroy** destroys AWS resources created by server-linux-aws-image, server-linux-aws-snapshot, server-linux-aws-infrastructure and server-linux-aws-application workflows.
 
 The workflow uses [infrastructure](infrastructure/README.md) and [application](application/README.md) Terraform templates with [infrastructure.tfvars.json](../../config/aws/arcgis-server-linux/infrastructure.tfvars.json) and [application.tfvars.json](../../config/aws/arcgis-server-linux/application.tfvars.json) config files.
 

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
@@ -20,6 +20,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
@@ -63,3 +64,9 @@ jobs:
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
           terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+      - name: Delete AMIs
+        id: delete-amis
+        run: |
+          SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
+          DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
+          python -m delete_deployment_amis -s $SITE_ID -d $DEPLOYMENT_ID

--- a/aws/iam-policies/ArcGISEnterpriseDestroy.json
+++ b/aws/iam-policies/ArcGISEnterpriseDestroy.json
@@ -4,6 +4,8 @@
         {
             "Effect": "Allow",
             "Action": [
+                "ec2:DeleteSnapshot",
+                "ec2:DeregisterImage",
                 "ec2:DetachNetworkInterface",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstanceAttribute",

--- a/aws/scripts/README.md
+++ b/aws/scripts/README.md
@@ -10,6 +10,24 @@ The scripts retrieve AWS credentials and region from environment variables:
 * AWS_SECRET_ACCESS_KEY - the secret key associated with the access key
 * AWS_DEFAULT_REGION - code of the default AWS region
 
+## delete_deployment_amis
+
+Deletes AMIs used by the specified deployment and SSM parameters referencing the AMIs.
+
+usage:
+
+```shell
+python -m delete_deployment_amis [-h] [-s SITE_ID] [-d DEPLOYMENT_ID]
+```
+
+options:
+
+```shell
+  -h, --help            show this help message and exit
+  -s SITE_ID            ArcGIS Enterprise site Id
+  -d DEPLOYMENT_ID      ArcGIS Enterprise deployment Id
+```
+
 ## downloads_api
 
 My Esri Downloads API repository client.

--- a/aws/scripts/delete_deployment_amis.py
+++ b/aws/scripts/delete_deployment_amis.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Esri
+#
+# Licensed under the Apache License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deletes AMIs used by the specified deployment and SSM parameters referencing the AMIs.
+
+import argparse
+import boto3
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='delete_deployment_amis.py',
+        description='Deletes AMIs used by the specified deployment and SSM parameters referencing the AMIs.')
+
+    parser.add_argument('-s', dest='site_id', required=True, help='ArcGIS Enterprise site Id')
+    parser.add_argument('-d', dest='deployment_id', required=True, help='ArcGIS Enterprise deployment Id')
+
+    args = parser.parse_args()
+
+    print(f'Deleting AMIs for deployment \"{args.deployment_id}\" in site \"{args.site_id}\"...')
+
+    ec2_client = boto3.client('ec2')
+    ssm_client = boto3.client('ssm')
+
+    # Get the AMIs used by the specified deployment
+    images = ec2_client.describe_images(
+        Owners=['self'],
+        Filters=[
+            {
+                'Name': 'tag:ArcGISDeploymentId',
+                'Values': [args.deployment_id]
+            },
+            {
+                'Name': 'tag:ArcGISSiteId',
+                'Values': [args.site_id]
+            }
+        ],
+        MaxResults=1000
+    )['Images']
+
+    for image in images:
+        image_id = image['ImageId']
+        image_name = image['Name']
+        print(f'Deleting AMI {image_id} ({image_name})...')
+        
+        ec2_client.deregister_image(ImageId=image_id)
+
+        # Delete the associated snapshots
+        for block_device in image['BlockDeviceMappings']:
+            if 'Ebs' in block_device:
+                snapshot_id = block_device['Ebs']['SnapshotId']
+                print(f'Deleting snapshot {snapshot_id}...')
+                ec2_client.delete_snapshot(SnapshotId=snapshot_id)
+
+    ssm_parameters = ssm_client.describe_parameters(
+        ParameterFilters=[
+            {
+                'Key': 'Name',
+                'Option': 'BeginsWith',
+                'Values': [
+                    f'/arcgis/{args.site_id}/images/{args.deployment_id}/'
+                ]
+            }
+        ]
+    )['Parameters']
+
+    for parameter in ssm_parameters:
+        parameter_name = parameter['Name']
+        print(f'Deleting SSM parameter {parameter_name}...')
+        ssm_client.delete_parameter(Name=parameter_name)
+
+    print('Done.')


### PR DESCRIPTION
The fix adds "Delete AMIs" step to enterprise-base-windows-aws-destroy, enterprise-base-linux-aws-destroy, and server-linux-aws-destroy workflows. The new step:

* Deregisters the deployments AMIs
* Deletes the AMI's EBS snapshots
* Deletes the `/arcgis/<site id>/images/<deployment id>/<machine role>` SSM parameters

Also, ec2:DeleteSnapshot and ec2:DeregisterImage permissions were added to ArcGISEnterpriseDestroy IAM policy.