### PR TITLE
#211 Change default deployment_id of arcgis-server-linux template

### DIFF
--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -101,7 +101,7 @@ The module reads the following SSM parameters:
 | aws_region | AWS region Id | `string` | n/a | yes |
 | config_store_type | ArcGIS Server configuration store type | `string` | `"FILESYSTEM"` | no |
 | deployment_fqdn | Fully qualified domain name of the ArcGIS Server deployment | `string` | n/a | yes |
-| deployment_id | Deployment Id | `string` | `"server"` | no |
+| deployment_id | Deployment Id | `string` | `"server-linux"` | no |
 | is_upgrade | Flag to indicate if this is an upgrade deployment | `bool` | `false` | no |
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |

--- a/aws/arcgis-server-linux/application/variables.tf
+++ b/aws/arcgis-server-linux/application/variables.tf
@@ -85,7 +85,7 @@ variable "deployment_fqdn" {
 variable "deployment_id" {
   description = "Deployment Id"
   type        = string
-  default     = "server"
+  default     = "server-linux"
 
   validation {
     condition     = can(regex("^[a-z0-9-]{3,25}$", var.deployment_id))

--- a/aws/arcgis-server-linux/backup/README.md
+++ b/aws/arcgis-server-linux/backup/README.md
@@ -44,7 +44,7 @@ The module retrieves the backup S3 bucket name from '/arcgis/${var.site_id}/s3/b
 | admin_password | ArcGIS Server administrator user password | `string` | n/a | yes |
 | admin_username | ArcGIS Server administrator user name | `string` | `"siteadmin"` | no |
 | aws_region | AWS region Id | `string` | n/a | yes |
-| deployment_id | Deployment Id | `string` | `"server"` | no |
+| deployment_id | Deployment Id | `string` | `"server-linux"` | no |
 | run_as_user | User name for the account used to run ArcGIS Server | `string` | `"arcgis"` | no |
 | s3_prefix | Backup S3 object keys prefix | `string` | `"arcgis-server-backups"` | no |
 | site_id | ArcGIS site Id | `string` | `"arcgis"` | no |

--- a/aws/arcgis-server-linux/backup/variables.tf
+++ b/aws/arcgis-server-linux/backup/variables.tf
@@ -42,7 +42,7 @@ variable "admin_username" {
 variable "deployment_id" {
   description = "Deployment Id"
   type        = string
-  default     = "server"
+  default     = "server-linux"
 
   validation {
     condition     = can(regex("^[a-z0-9-]{3,25}$", var.deployment_id))

--- a/aws/arcgis-server-linux/image/README.md
+++ b/aws/arcgis-server-linux/image/README.md
@@ -56,7 +56,7 @@ The template uses the following SSM parameters:
 | aws_region | AWS region Id | `string` | `env("AWS_DEFAULT_REGION")` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install | `string` | `[]` | no |
 | arcgis_version | ArcGIS Server version | `string` | `"11.4"` | no |
-| deployment_id | Deployment Id | `string` | `"server"` | no |
+| deployment_id | Deployment Id | `string` | `"server-linux"` | no |
 | instance_type | EC2 instance type | `string` | `"6i.xlarge"` | no |
 | os | Operating system | `string` | `"rhel8"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |

--- a/aws/arcgis-server-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-server-linux/image/variables.pkr.hcl
@@ -38,7 +38,7 @@ variable "arcgis_version" {
 variable "deployment_id" {
   description = "Deployment Id"
   type        = string
-  default     = "server"
+  default     = "server-linux"
 
   validation {
     condition     = can(regex("^[a-z0-9-]{3,25}$", var.deployment_id))

--- a/aws/arcgis-server-linux/infrastructure/README.md
+++ b/aws/arcgis-server-linux/infrastructure/README.md
@@ -126,7 +126,7 @@ The module writes the following SSM parameters:
 | aws_region | AWS region Id | `string` | n/a | yes |
 | client_cidr_blocks | Client CIDR blocks | `list(string)` | ```[ "0.0.0.0/0" ]``` | no |
 | deployment_fqdn | Fully qualified domain name of the ArcGIS Server deployment | `string` | `null` | no |
-| deployment_id | ArcGIS Server deployment Id | `string` | `"server"` | no |
+| deployment_id | ArcGIS Server deployment Id | `string` | `"server-linux"` | no |
 | instance_type | EC2 instance type | `string` | `"m6i.2xlarge"` | no |
 | internal_load_balancer | If true, the load balancer scheme is set to 'internal' | `bool` | `false` | no |
 | key_name | EC2 key pair name | `string` | n/a | yes |

--- a/aws/arcgis-server-linux/infrastructure/variables.tf
+++ b/aws/arcgis-server-linux/infrastructure/variables.tf
@@ -55,7 +55,7 @@ variable "deployment_fqdn" {
 variable "deployment_id" {
   description = "ArcGIS Server deployment Id"
   type        = string
-  default     = "server"
+  default     = "server-linux"
 
   validation {
     condition     = can(regex("^[a-z0-9-]{3,25}$", var.deployment_id))

--- a/aws/arcgis-server-linux/restore/README.md
+++ b/aws/arcgis-server-linux/restore/README.md
@@ -48,7 +48,7 @@ The module retrieves the backup S3 bucket name and region from '/arcgis/${var.ba
 | admin_username | ArcGIS Server administrator user name | `string` | `"siteadmin"` | no |
 | aws_region | AWS region Id | `string` | n/a | yes |
 | backup_site_id | ArcGIS site Id of the backup to restore from | `string` | `"arcgis"` | no |
-| deployment_id | Deployment Id | `string` | `"server"` | no |
+| deployment_id | Deployment Id | `string` | `"server-linux"` | no |
 | run_as_user | User name for the account used to run ArcGIS Server | `string` | `"arcgis"` | no |
 | s3_prefix | Backup S3 object keys prefix | `string` | `"arcgis-server-backups"` | no |
 | site_id | ArcGIS site Id | `string` | `"arcgis"` | no |

--- a/aws/arcgis-server-linux/restore/variables.tf
+++ b/aws/arcgis-server-linux/restore/variables.tf
@@ -53,7 +53,7 @@ variable "backup_site_id" {
 variable "deployment_id" {
   description = "Deployment Id"
   type        = string
-  default     = "server"
+  default     = "server-linux"
 
   validation {
     condition     = can(regex("^[a-z0-9-]{3,25}$", var.deployment_id))

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -8,7 +8,7 @@
   "arcgis_version": "11.4",
   "config_store_type": "FILESYSTEM",
   "deployment_fqdn": "<deployment_fqdn>",
-  "deployment_id": "server",
+  "deployment_id": "server-linux",
   "is_upgrade": false,
   "keystore_file_password": "",
   "keystore_file_path": null,

--- a/config/aws/arcgis-server-linux/backup.tfvars.json
+++ b/config/aws/arcgis-server-linux/backup.tfvars.json
@@ -1,7 +1,7 @@
 {
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
-  "deployment_id": "server",
+  "deployment_id": "server-linux",
   "run_as_user": "arcgis",
   "s3_prefix": "arcgis-server-backups",
   "site_id": "arcgis"

--- a/config/aws/arcgis-server-linux/image.vars.json
+++ b/config/aws/arcgis-server-linux/image.vars.json
@@ -3,7 +3,7 @@
     "ArcGIS-114-S-*-linux.tar"
   ],
   "arcgis_version": "11.4",
-  "deployment_id": "server",
+  "deployment_id": "server-linux",
   "instance_type": "m6i.2xlarge",
   "os": "rhel8",
   "root_volume_size": 100,

--- a/config/aws/arcgis-server-linux/infrastructure.tfvars.json
+++ b/config/aws/arcgis-server-linux/infrastructure.tfvars.json
@@ -2,7 +2,7 @@
   "alb_deployment_id": "enterprise-base-linux",
   "client_cidr_blocks": ["0.0.0.0/0"],
   "deployment_fqdn": "<deployment_fqdn>",
-  "deployment_id": "server",
+  "deployment_id": "server-linux",
   "instance_type": "m6i.2xlarge",
   "internal_load_balancer": false,
   "key_name": null,

--- a/config/aws/arcgis-server-linux/restore.tfvars.json
+++ b/config/aws/arcgis-server-linux/restore.tfvars.json
@@ -2,7 +2,7 @@
   "admin_password": "<admin_password>",
   "admin_username": "siteadmin",
   "backup_site_id": "arcgis",  
-  "deployment_id": "server",
+  "deployment_id": "server-linux",
   "run_as_user": "arcgis",
   "s3_prefix": "arcgis-server-backups",
   "site_id": "arcgis"


### PR DESCRIPTION
The fix changes the default "deployment_id" in arcgis-server-linux template from "server" to "server-linux".