### PR TITLE
#214 Default delete_namespace to true

### DIFF
--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-destroy.yaml
@@ -21,7 +21,7 @@ on:
         description: 'Delete namespace'
         type: boolean
         required: true
-        default: false
+        default: true
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -68,7 +68,7 @@ jobs:
           terraform destroy -var-file $ORGANIZATION_CONFIG_FILE -auto-approve
       - name: Destroy Ingress
         id: destroy-ingress
-        if: ${{ inputs.delete_namespace }} 
+        if: ${{ inputs.delete_namespace != false }}
         working-directory: aws/arcgis-enterprise-k8s/ingress
         run: |
           SITE_ID=$(jq -r '.site_id' $INGRESS_CONFIG_FILE)

--- a/azure/arcgis-enterprise-k8s/workflows/enterprise-k8s-azure-destroy.yaml
+++ b/azure/arcgis-enterprise-k8s/workflows/enterprise-k8s-azure-destroy.yaml
@@ -21,7 +21,7 @@ on:
         description: 'Delete namespace'
         type: boolean
         required: true
-        default: false
+        default: true
 
 env:
   TF_VAR_azure_region: ${{ vars.AZURE_DEFAULT_REGION }}
@@ -74,7 +74,7 @@ jobs:
           terraform destroy -var-file $ORGANIZATION_CONFIG_FILE -auto-approve
       - name: Destroy Ingress
         id: destroy-ingress
-        if: ${{ inputs.delete_namespace }} 
+        if: ${{ inputs.delete_namespace != false }}
         working-directory: azure/arcgis-enterprise-k8s/ingress
         run: |
           SITE_ID=$(jq -r '.site_id' $INGRESS_CONFIG_FILE)


### PR DESCRIPTION
Set default "delete_namespace" input in enterprise-k8s-aws-destroy and enterprise-k8s-azure-destroy workflows to true.