### PR TITLE
#179 Get web context from config file in test workflows

### DIFF
--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-test.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-test.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Run Tests
       run: |
         DEPLOYMENT_FQDN=$(jq -r '.deployment_fqdn' $CONFIG_FILE)
-        ARCGIS_ENTERPRISE_CONTEXT=portal
+        PORTAL_WEB_CONTEXT=$(jq -r '.portal_web_context' $CONFIG_FILE)
         ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
         ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
-        docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT
+        docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$PORTAL_WEB_CONTEXT

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-test.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-test.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Run Tests
       run: |
         DEPLOYMENT_FQDN=$(jq -r '.deployment_fqdn' $CONFIG_FILE)
-        ARCGIS_ENTERPRISE_CONTEXT=portal
+        PORTAL_WEB_CONTEXT=$(jq -r '.portal_web_context' $CONFIG_FILE)
         ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
         ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
-        docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT
+        docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$PORTAL_WEB_CONTEXT

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-test.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-test.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Run Tests
       run: |
         DEPLOYMENT_FQDN=$(jq -r '.deployment_fqdn' $CONFIG_FILE)
-        ARCGIS_ENTERPRISE_CONTEXT=$(jq -r '.server_web_context' $CONFIG_FILE)
+        SERVER_WEB_CONTEXT=$(jq -r '.server_web_context' $CONFIG_FILE)
         ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
         ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
-        docker run -e ARCGIS_SERVER_USER=$ADMIN_USERNAME -e ARCGIS_SERVER_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-server-admin --url https://$DEPLOYMENT_FQDN/$ARCGIS_ENTERPRISE_CONTEXT
+        docker run -e ARCGIS_SERVER_USER=$ADMIN_USERNAME -e ARCGIS_SERVER_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-server-admin --url https://$DEPLOYMENT_FQDN/$SERVER_WEB_CONTEXT


### PR DESCRIPTION
The fix changes enterprise-base-linux-aws-test and enterprise-base-windows-aws-test workflows to retrieve portal web context from the config files instead of using the hardcoded "portal".