### PR TITLE
#207 Verify notebook_server_authorization_file_path

### DIFF
--- a/aws/scripts/verify_site_config.py
+++ b/aws/scripts/verify_site_config.py
@@ -36,6 +36,7 @@ SKIP_PROPERTIES = [
 FILE_PATH_PROPERTIES = [
     "portal_authorization_file_path",
     "server_authorization_file_path",
+    "notebook_server_authorization_file_path",
     "keystore_file_path",
     "tls_certificate_path",
     "tls_private_key_path",


### PR DESCRIPTION
The fix makes verify-site-config-aws workflow check if the file specified by "notebook_server_authorization_file_path" property exists.