### PR TITLE
#220 Retrieve admin user credentials from GitHub Actions secrets

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -21,7 +21,21 @@ Initial deployment of base ArcGIS Enterprise includes building images, provision
 
 ![Base ArcGIS Enterprise on Linux Configuration Flow](./arcgis-enterprise-base-linux-flowchart.png)
 
-### 1. Build Images
+### 1. Set GitHub Actions Secrets for the Site
+
+Set the primary ArcGIS Enterprise site administrator credentials in the GitHub Actions secrets of the repository settings.
+
+| Name                      | Description                                    |
+|---------------------------|------------------------------------------------|
+| ENTERPRISE_ADMIN_USERNAME | ArcGIS Enterprise administrator user name      |
+| ENTERPRISE_ADMIN_PASSWORD | ArcGIS Enterprise administrator user password  |
+| ENTERPRISE_ADMIN_EMAIL    | ArcGIS Enterprise administrator e-mail address |
+
+> The ArcGIS Enterprise administrator user name must be between 6 and 128 characters long and can consist only of uppercase and lowercase ASCII letters, numbers, and dots (.).
+
+> The ArcGIS Enterprise administrator user password must be between 8 and 128 characters long and can consist only of uppercase and lowercase ASCII letters, numbers, and dots (.).
+
+### 2. Build Images
 
 GitHub Actions workflow **enterprise-base-linux-aws-image** creates EC2 AMIs for base ArcGIS Enterprise deployment.
 
@@ -39,7 +53,7 @@ Instructions:
 
 > In the configuration files, "os" and "arcgis_version" properties values for the same deployment must match across all the configuration files of the deployment.
 
-### 2. Provision AWS Resources
+### 3. Provision AWS Resources
 
 GitHub Actions workflow **enterprise-base-linux-aws-infrastructure** creates AWS resources for base ArcGIS Enterprise deployment.
 
@@ -72,7 +86,7 @@ Instructions:
 
 > When updating the infrastructure, first run the workflow with terraform_command=plan before running it with terraform_command=apply and check the logs to make sure that Terraform does not destroy and recreate critical AWS resources such as EC2 instances.
 
-### 3. Configure Applications
+### 4. Configure Applications
 
 GitHub Actions workflow **enterprise-base-linux-aws-application** configures or upgrades base ArcGIS Enterprise on EC2 instances.
 
@@ -95,14 +109,14 @@ Instructions:
 
 1. Add Portal for ArcGIS and ArcGIS Server authorization files for the ArcGIS Enterprise version to `config/authorization/<ArcGIS version>` directory of the repository and set "portal_authorization_file_path" and "server_authorization_file_path" properties to the file paths.
 2. Set "deployment_fqdn" property to the base ArcGIS Enterprise deployment fully qualified domain name.
-3. Set "admin_username", "admin_password", "admin_full_name", "admin_description", "admin_email", "security_question", and "security_question_answer" to the initial ArcGIS Enterprise administrator account properties.
+3. Set "admin_full_name", "admin_description", "security_question", and "security_question_answer" to the initial ArcGIS Enterprise administrator account properties.
 4. (Optionally) Add SSL certificates for the base ArcGIS Enterprise domain name and trusted root certificates to `config/certificates` directory and set "keystore_file_path" and "root_cert_file_path" properties to the file paths. Set "keystore_file_password" property to password of the keystore file.
 5. Commit the changes to the Git branch and push the branch to GitHub.
 6. Run enterprise-base-linux-aws-application workflow using the branch.
 
 > '~/config/' paths is linked to the repository's /config directory. It's recommended to use /config directory for the configuration files.
 
-### 4. Test Base ArcGIS Enterprise Deployment
+### 5. Test Base ArcGIS Enterprise Deployment
 
 GitHub Actions workflow **enterprise-base-linux-aws-test** tests base ArcGIS Enterprise deployment.
 
@@ -129,9 +143,7 @@ Required IAM policies:
 
 Instructions:
 
-1. Set "admin_username" and "admin_password" properties to the portal administrator user name and password respectively.
-2. Commit the changes to the Git branch and push the branch to GitHub.
-3. Run enterprise-base-linux-aws-backup workflow using the branch.
+1. Run enterprise-base-linux-aws-backup workflow using the main/default branch.
 
 To meet the required recovery point objective (RPO), schedule runs of enterprise-base-linux-aws-backup workflow by configuring 'schedule' event in enterprise-base-linux-aws-backup.yaml file. When the backup workflow is triggered manually, the backup-restore mode is specified by the workflow inputs. However, when the workflow is triggered on schedule, the backup-restore mode is retrieved from the backup.tfvars.json config file. Note that scheduled workflows run on the latest commit on the `main` (or default) branch.
 
@@ -150,9 +162,7 @@ Required IAM policies:
 
 Instructions:
 
-1. Set "admin_username" and "admin_password" properties to the portal administrator user name and password respectively.
-2. Commit the changes to the Git branch and push the branch to GitHub.
-3. Run enterprise-base-linux-aws-restore workflow using the branch.
+1. Run enterprise-base-linux-aws-restore workflow using the main/default branch.
 
 ### Create Snapshots and Restore from Snapshots
 

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-application.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-application.yaml
@@ -22,6 +22,9 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-backup.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-backup.yaml
@@ -32,6 +32,8 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-linux/backup.tfvars.json
 

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
@@ -23,6 +23,9 @@ env:
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}  
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-restore.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-restore.yaml
@@ -30,6 +30,8 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-linux/restore.tfvars.json
 

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-test.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-test.yaml
@@ -18,6 +18,8 @@ on:
   workflow_dispatch:
  
 env:
+  ADMIN_USERNAME: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  ADMIN_PASSWORD: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
 
 jobs:
@@ -40,6 +42,4 @@ jobs:
       run: |
         DEPLOYMENT_FQDN=$(jq -r '.deployment_fqdn' $CONFIG_FILE)
         PORTAL_WEB_CONTEXT=$(jq -r '.portal_web_context' $CONFIG_FILE)
-        ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
-        ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
         docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$PORTAL_WEB_CONTEXT

--- a/aws/arcgis-enterprise-base-windows/image/README.md
+++ b/aws/arcgis-enterprise-base-windows/image/README.md
@@ -65,7 +65,7 @@ The template uses the following SSM parameters:
 | os | Operating system Id | `string` | `"windows2022"` | no |
 | portal_web_context | Portal for ArcGIS web context | `string` | `"portal"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |
-| run_as_password | Password for the account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store. | `string` | | yes |
+| run_as_password | Password for the account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store. | `string` | `env("RUN_AS_PASSWORD")` | yes |
 | run_as_user | User account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store. | `string` | `"arcgis"` | no |
 | server_web_context | ArcGIS Server web context | `string` | `"server"` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis"` | no |

--- a/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
@@ -101,6 +101,7 @@ variable "run_as_password" {
   description = "Password for the account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store."
   type        = string
   sensitive   = true
+  default     = env("RUN_AS_PASSWORD")
 }
 
 variable "arcgis_portal_patches" {

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-application.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-application.yaml
@@ -22,6 +22,10 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
+  TF_VAR_run_as_password: ${{ secrets.RUN_AS_PASSWORD }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-backup.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-backup.yaml
@@ -32,6 +32,9 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_run_as_password: ${{ secrets.RUN_AS_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-windows/backup.tfvars.json
 

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
@@ -23,6 +23,10 @@ env:
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}  
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
+  TF_VAR_run_as_password: ${{ secrets.RUN_AS_PASSWORD }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-image.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-image.yaml
@@ -24,6 +24,7 @@ env:
   AWS_MAX_ATTEMPTS: 400
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
+  RUN_AS_PASSWORD: ${{ secrets.RUN_AS_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-windows/image.vars.json
 

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-restore.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-restore.yaml
@@ -30,6 +30,9 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_run_as_password: ${{ secrets.RUN_AS_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-windows/restore.tfvars.json
 

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-test.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-test.yaml
@@ -18,6 +18,8 @@ on:
   workflow_dispatch:
  
 env:
+  ADMIN_USERNAME: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  ADMIN_PASSWORD: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
 
 jobs:
@@ -40,6 +42,4 @@ jobs:
       run: |
         DEPLOYMENT_FQDN=$(jq -r '.deployment_fqdn' $CONFIG_FILE)
         PORTAL_WEB_CONTEXT=$(jq -r '.portal_web_context' $CONFIG_FILE)
-        ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
-        ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
         docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-publish-csv --url https://$DEPLOYMENT_FQDN/$PORTAL_WEB_CONTEXT

--- a/aws/arcgis-notebook-server-linux/README.md
+++ b/aws/arcgis-notebook-server-linux/README.md
@@ -89,10 +89,9 @@ Instructions:
 
 1. Add ArcGIS Notebook Server authorization file to `config/authorization/<ArcGIS version>` directory of the repository and set "notebook_server_authorization_file_path" properties to the file path.
 2. Set "deployment_fqdn" property to the ArcGIS Notebook Server deployment fully qualified domain name.
-3. Set "admin_username", "admin_password", and "admin_email" to the initial ArcGIS Notebook Server administrator account properties.
-4. Set "portal_url", "portal_username", and "portal_password" properties to the base ArcGIS Enterprise portal URL (`"https://<deployment_fqdn>/portal"`) and the administrator account credentials.
-5. Commit the changes to the Git branch and push the branch to GitHub.
-6. Run the notebook-server-linux-aws-application workflow using the branch.
+3. Set "portal_url" property to the base ArcGIS Enterprise portal URL.
+4. Commit the changes to the Git branch and push the branch to GitHub.
+5. Run the notebook-server-linux-aws-application workflow using the branch.
 
 > '~/config/' paths is linked to the repository's /config directory. It's recommended to use /config directory for the configuration files.
 
@@ -123,9 +122,7 @@ Required IAM policies:
 
 Instructions:
 
-1. Set "admin_username" and "admin_password" properties to the ArcGIS Notebook Server administrator user name and password respectively.
-2. Commit the changes to the Git branch and push the branch to GitHub.
-3. Run the notebook-server-linux-aws-backup workflow using the branch.
+1. Run the notebook-server-linux-aws-backup workflow using the main/default branch.
 
 To meet the required recovery point objective (RPO), schedule runs of notebook-server-linux-aws-backup workflow by configuring 'schedule' event in notebook-server-linux-aws-backup.yaml file. Note that scheduled workflows run on the latest commit on the `main` (or default) branch.
 
@@ -142,9 +139,7 @@ Required IAM policies:
 
 Instructions:
 
-1. Set "admin_username" and "admin_password" properties to the portal administrator user name and password respectively.
-2. Commit the changes to the Git branch and push the branch to GitHub.
-3. Run the notebook-server-linux-aws-restore workflow using the branch.
+1. Run the notebook-server-linux-aws-restore workflow using the main/default branch.
 
 ### Create Snapshots and Restore from Snapshots
 

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-application.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-application.yaml
@@ -22,6 +22,11 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
+  TF_VAR_portal_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_portal_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-backup.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-backup.yaml
@@ -23,6 +23,8 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+  ADMIN_USERNAME: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  ADMIN_PASSWORD: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-notebook-server-linux/backup.vars.json
 
@@ -51,6 +53,6 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         LOGS_S3_BUCKET=$(aws ssm get-parameter --name "/arcgis/$SITE_ID/s3/logs" --query "Parameter.Value" --output text)
-        export JSON_ATTRIBUTES=$(cat $CONFIG_FILE | base64)
-        JSON_ATTRIBUTES_PARAMETER="/arcgis/$SITE_ID/attributes/$DEPLOYMENT_ID/arcgis-notebook-server/backup"
+        export JSON_ATTRIBUTES=$(cat $CONFIG_FILE | jq ".admin_username += \"$ADMIN_USERNAME\"" | jq ".admin_password += \"$ADMIN_PASSWORD\"" | base64)
+        JSON_ATTRIBUTES_PARAMETER="/arcgis/$SITE_ID/attributes/$DEPLOYMENT_ID/backup"
         python -m ssm_run_shell_script -s $SITE_ID -d $DEPLOYMENT_ID -m primary -j $JSON_ATTRIBUTES_PARAMETER -f exportSite.sh -b $LOGS_S3_BUCKET -e 600

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-destroy.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-destroy.yaml
@@ -23,6 +23,11 @@ env:
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}  
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
+  TF_VAR_portal_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_portal_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-restore.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-restore.yaml
@@ -20,7 +20,9 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}  
+  AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+  ADMIN_USERNAME: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  ADMIN_PASSWORD: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-notebook-server-linux/restore.vars.json
 
@@ -49,6 +51,6 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         LOGS_S3_BUCKET=$(aws ssm get-parameter --name "/arcgis/$SITE_ID/s3/logs" --query "Parameter.Value" --output text)
-        export JSON_ATTRIBUTES=$(cat $CONFIG_FILE | base64)
-        JSON_ATTRIBUTES_PARAMETER="/arcgis/$SITE_ID/attributes/$DEPLOYMENT_ID/arcgis-notebook-server/restore"
+        export JSON_ATTRIBUTES=$(cat $CONFIG_FILE | jq ".admin_username += \"$ADMIN_USERNAME\"" | jq ".admin_password += \"$ADMIN_PASSWORD\"" | base64)
+        JSON_ATTRIBUTES_PARAMETER="/arcgis/$SITE_ID/attributes/$DEPLOYMENT_ID/restore"
         python -m ssm_run_shell_script -s $SITE_ID -d $DEPLOYMENT_ID -m primary -j $JSON_ATTRIBUTES_PARAMETER -f importSite.sh -b $LOGS_S3_BUCKET -e 600

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-test.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-test.yaml
@@ -18,6 +18,8 @@ on:
   workflow_dispatch:
  
 env:
+  ADMIN_USERNAME: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  ADMIN_PASSWORD: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-notebook-server-linux/application.tfvars.json
 
 jobs:
@@ -42,6 +44,4 @@ jobs:
         NOTEBOOK_SERVER_WEB_CONTEXT=$(jq -r '.notebook_server_web_context' $CONFIG_FILE)
         NB_URL=https://$DEPLOYMENT_FQDN/$NOTEBOOK_SERVER_WEB_CONTEXT
         PORTAL_URL=$(jq -r '.portal_url' $CONFIG_FILE)
-        ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
-        ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
         docker run -e ARCGIS_ENTERPRISE_USER=$ADMIN_USERNAME -e ARCGIS_ENTERPRISE_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-nb-admin --nb-url $NB_URL --url $PORTAL_URL

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -19,7 +19,21 @@ Initial deployment of ArcGIS Server includes building images, provisioning AWS r
 
 ![ArcGIS Server on Linux Configuration Flow](./arcgis-server-linux-flowchart.png)
 
-### 1. Build Images
+### 1. Set GitHub Actions Secrets for the Site
+
+If ArcGIS Server is deployed as a standalone server or federated with ArcGIS Enterprise on Kubernetes, set the primary ArcGIS Server site administrator credentials in the GitHub Actions secrets of the repository settings.
+
+| Name                      | Description                                |
+|---------------------------|--------------------------------------------|
+| ENTERPRISE_ADMIN_USERNAME | ArcGIS Server administrator user name      |
+| ENTERPRISE_ADMIN_PASSWORD | ArcGIS Server administrator user password  |
+| ENTERPRISE_ADMIN_EMAIL    | ArcGIS Server administrator e-mail address |
+
+> The ArcGIS Server administrator user name must be between 6 and 128 characters long and can consist only of uppercase and lowercase ASCII letters, numbers, and dots (.).
+
+> The ArcGIS Server administrator user password must be between 8 and 128 characters long and can consist only of uppercase and lowercase ASCII letters, numbers, and dots (.).
+
+### 2. Build Images
 
 GitHub Actions workflow **server-linux-aws-image** creates EC2 AMIs for ArcGIS Server deployment.
 
@@ -39,7 +53,7 @@ Instructions:
 
 > In the configuration files, "os" and "arcgis_version" properties values for the same deployment must match across all the configuration files of the deployment.
 
-### 2. Provision AWS Resources
+### 3. Provision AWS Resources
 
 GitHub Actions workflow **server-linux-aws-infrastructure** creates AWS resources for ArcGIS Server deployment.
 
@@ -73,7 +87,7 @@ Instructions:
 
 > When updating the infrastructure, first run the workflow with terraform_command=plan before running it with terraform_command=apply and check the logs to make sure that Terraform does not destroy and recreate critical AWS resources such as EC2 instances.
 
-### 3. Configure Applications
+### 4. Configure Applications
 
 GitHub Actions workflow **server-linux-aws-application** configures or upgrades ArcGIS Server on EC2 instances.
 
@@ -105,7 +119,7 @@ Instructions:
 
 > '~/config/' paths is linked to the repository's /config directory. It's recommended to use /config directory for the configuration files.
 
-### 4. Test ArcGIS Server Deployment
+### 5. Test ArcGIS Server Deployment
 
 GitHub Actions workflow **server-linux-aws-test** tests ArcGIS Server deployment.
 

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
@@ -22,6 +22,11 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
+  TF_VAR_portal_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_portal_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-backup.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-backup.yaml
@@ -24,6 +24,8 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-server-linux/backup.tfvars.json
 

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
@@ -23,6 +23,9 @@ env:
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
+  TF_VAR_admin_email: ${{ secrets.ENTERPRISE_ADMIN_EMAIL }}
   ARCGIS_ONLINE_USERNAME: ${{ secrets.ARCGIS_ONLINE_USERNAME }}
   ARCGIS_ONLINE_PASSWORD: ${{ secrets.ARCGIS_ONLINE_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-restore.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-restore.yaml
@@ -22,6 +22,8 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TERRAFORM_BACKEND_S3_BUCKET: ${{ vars.TERRAFORM_BACKEND_S3_BUCKET }}
   TF_VAR_aws_region: ${{ vars.AWS_DEFAULT_REGION }}
+  TF_VAR_admin_username: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  TF_VAR_admin_password: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   PYTHONPATH: ${{ github.workspace }}/aws/scripts
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-server-linux/restore.tfvars.json
 

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-test.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-test.yaml
@@ -18,6 +18,8 @@ on:
   workflow_dispatch:
  
 env:
+  ADMIN_USERNAME: ${{ secrets.ENTERPRISE_ADMIN_USERNAME }}
+  ADMIN_PASSWORD: ${{ secrets.ENTERPRISE_ADMIN_PASSWORD }}
   CONFIG_FILE: ${{ github.workspace }}/config/aws/arcgis-server-linux/application.tfvars.json
 
 jobs:
@@ -40,6 +42,4 @@ jobs:
       run: |
         DEPLOYMENT_FQDN=$(jq -r '.deployment_fqdn' $CONFIG_FILE)
         SERVER_WEB_CONTEXT=$(jq -r '.server_web_context' $CONFIG_FILE)
-        ADMIN_USERNAME=$(jq -r '.admin_username' $CONFIG_FILE)
-        ADMIN_PASSWORD=$(jq -r '.admin_password' $CONFIG_FILE)
         docker run -e ARCGIS_SERVER_USER=$ADMIN_USERNAME -e ARCGIS_SERVER_PASSWORD=$ADMIN_PASSWORD enterprise-admin-cli gis test-server-admin --url https://$DEPLOYMENT_FQDN/$SERVER_WEB_CONTEXT

--- a/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
@@ -1,9 +1,6 @@
 {
   "admin_description": "Initial account administrator",
-  "admin_email": "<admin_email>",
   "admin_full_name": "<admin_full_name>",
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "arcgis_data_store_patches": [
     "ArcGIS-114-DS-*-linux.tar"
   ],

--- a/config/aws/arcgis-enterprise-base-linux/backup.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/backup.tfvars.json
@@ -1,6 +1,4 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "backup_restore_mode": "backup",
   "deployment_id": "enterprise-base-linux",
   "execution_timeout": 36000,

--- a/config/aws/arcgis-enterprise-base-linux/restore.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/restore.tfvars.json
@@ -1,6 +1,4 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "backup_restore_mode": "backup",
   "backup_site_id": "arcgis",
   "deployment_id": "enterprise-base-linux",

--- a/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
@@ -1,9 +1,6 @@
 {
   "admin_description": "Initial account administrator",
-  "admin_email": "<admin_email>",
   "admin_full_name": "<admin_full_name>",
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "arcgis_data_store_patches": [
     "ArcGIS-114-DS-*.msp"
   ],
@@ -27,7 +24,6 @@
   "portal_user_license_type_id": "creatorUT",
   "portal_web_context": "portal",
   "root_cert_file_path": null,
-  "run_as_password": "<run_as_password>",
   "run_as_user": "arcgis",
   "security_question_answer": "<security_question_answer>",
   "security_question": "What city were you born in?",

--- a/config/aws/arcgis-enterprise-base-windows/backup.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/backup.tfvars.json
@@ -1,11 +1,8 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "backup_restore_mode": "backup",
   "deployment_id": "enterprise-base-windows",
   "execution_timeout": 36000,
   "portal_admin_url": "https://localhost:7443/arcgis",
-  "run_as_password": "<run_as_password>",
   "run_as_user": "arcgis",
   "site_id": "arcgis"
 }

--- a/config/aws/arcgis-enterprise-base-windows/image.vars.json
+++ b/config/aws/arcgis-enterprise-base-windows/image.vars.json
@@ -15,7 +15,6 @@
   "os": "windows2022",
   "portal_web_context": "portal",
   "root_volume_size": 100,
-  "run_as_password": "<run_as_password>",
   "run_as_username": "arcgis",
   "server_web_context": "server",
   "site_id": "arcgis",

--- a/config/aws/arcgis-enterprise-base-windows/restore.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/restore.tfvars.json
@@ -1,12 +1,9 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "backup_restore_mode": "backup",
   "backup_site_id": "arcgis",
   "deployment_id": "enterprise-base-windows",
   "execution_timeout": 36000,
   "portal_admin_url": "https://localhost:7443/arcgis",
-  "run_as_password": "<run_as_password>",
   "run_as_user": "arcgis",
   "site_id": "arcgis"
 }

--- a/config/aws/arcgis-notebook-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-notebook-server-linux/application.tfvars.json
@@ -1,7 +1,4 @@
 {
-  "admin_email": "<admin_email>",
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "arcgis_notebook_server_patches": [
     "ArcGIS-114-NS-*.tar",
     "ArcGIS-114-NS-*.tar.gz"
@@ -21,9 +18,7 @@
   "notebook_server_web_context": "notebooks",
   "os": "ubuntu22",
   "portal_org_id": null,
-  "portal_password": "<portal_password>",
   "portal_url": "<portal_url>",
-  "portal_username": "<portal_username>",
   "root_cert_file_path": null,
   "run_as_user": "arcgis",
   "site_id": "arcgis"

--- a/config/aws/arcgis-notebook-server-linux/backup.vars.json
+++ b/config/aws/arcgis-notebook-server-linux/backup.vars.json
@@ -1,6 +1,4 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "deployment_id": "notebook-server-linux",
   "run_as_user": "arcgis",
   "site_id": "arcgis",

--- a/config/aws/arcgis-notebook-server-linux/restore.vars.json
+++ b/config/aws/arcgis-notebook-server-linux/restore.vars.json
@@ -1,6 +1,4 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "backup_site_id": "arcgis",
   "deployment_id": "notebook-server-linux",
   "run_as_user": "arcgis",

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -1,7 +1,4 @@
 {
-  "admin_email": "<admin_email>",
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "arcgis_server_patches": [
     "ArcGIS-114-S-*-linux.tar"
   ],
@@ -15,15 +12,13 @@
   "log_level": "WARNING",
   "os": "rhel8",
   "portal_org_id": null,
-  "portal_password": "<portal_password>",
-  "portal_url": "<portal_url>",
-  "portal_username": "<portal_username>",
+  "portal_url": null,
   "root_cert_file_path": null,
   "run_as_user": "arcgis",
   "server_authorization_file_path": "~/config/authorization/11.4/server_114.prvc",
   "server_authorization_options": "",
   "server_functions": [],
-  "server_role": "FEDERATED_SERVER",
+  "server_role": "",
   "server_web_context": "arcgis",
   "services_dir_enabled": true,
   "site_id": "arcgis",

--- a/config/aws/arcgis-server-linux/backup.tfvars.json
+++ b/config/aws/arcgis-server-linux/backup.tfvars.json
@@ -1,6 +1,4 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "deployment_id": "server-linux",
   "run_as_user": "arcgis",
   "s3_prefix": "arcgis-server-backups",

--- a/config/aws/arcgis-server-linux/infrastructure.tfvars.json
+++ b/config/aws/arcgis-server-linux/infrastructure.tfvars.json
@@ -1,5 +1,5 @@
 {
-  "alb_deployment_id": "enterprise-base-linux",
+  "alb_deployment_id": null,
   "client_cidr_blocks": ["0.0.0.0/0"],
   "deployment_fqdn": "<deployment_fqdn>",
   "deployment_id": "server-linux",
@@ -12,7 +12,7 @@
   "root_volume_throughput": 125,
   "server_web_context": "arcgis",
   "site_id": "arcgis",
-  "ssl_certificate_arn": null,
+  "ssl_certificate_arn": "<ssl_certificate_arn>",
   "ssl_policy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
   "subnet_ids": [],
   "use_webadaptor": true

--- a/config/aws/arcgis-server-linux/restore.tfvars.json
+++ b/config/aws/arcgis-server-linux/restore.tfvars.json
@@ -1,6 +1,4 @@
 {
-  "admin_password": "<admin_password>",
-  "admin_username": "siteadmin",
   "backup_site_id": "arcgis",  
   "deployment_id": "server-linux",
   "run_as_user": "arcgis",


### PR DESCRIPTION
The fix changes arcgis-enterprise-base-linux, arcgis-enterprise-base-windows, arcgis-notebook-server-linux, and 
arcgis-server-linux templates to retrieve the primary admin credentials and password of 'arcgis' windows user account from GitHub Actions secrets instead of config files.

| Name                                             | Description                                                         |
|--------------------------------------|----------------------------------------------------|
| ENTERPRISE_ADMIN_USERNAME | ArcGIS Enterprise administrator user name        |
| ENTERPRISE_ADMIN_PASSWORD | ArcGIS Enterprise administrator user password  |
| ENTERPRISE_ADMIN_EMAIL          | ArcGIS Enterprise administrator e-mail address |
| RUN_AS_PASSWORD                     | Password of 'arcgis' windows user account  (Windows only)  |
