### PR TITLE
#229 Support RHEL9 and GPUs in Notebook Server template

### DIFF
--- a/config/aws/arcgis-site-core/infrastructure-core.tfvars.json
+++ b/config/aws/arcgis-site-core/infrastructure-core.tfvars.json
@@ -40,7 +40,7 @@
       "owner": "309956199498"
     },
     "rhel9": {
-      "ami_name_filter": "RHEL-9.6.0_HVM-*-x86_64-*-Hourly2-GP3",
+      "ami_name_filter": "RHEL-9.3.0_HVM-*-x86_64-*-Hourly2-GP3",
       "description": "Red Hat Enterprise Linux version 9 (HVM), EBS General Purpose (SSD) Volume Type",
       "owner": "309956199498"
     },


### PR DESCRIPTION
"RHEL-9.6.0_HVM-*-x86_64-*-Hourly2-GP3" AMI is not yet available. Changed the filter back to "RHEL-9.3.0_HVM-*-x86_64-*-Hourly2-GP3".