### PR TITLE
#230 Updated supported operating systems

### DIFF
--- a/ansible_collections/arcgis/webadaptor/playbooks/install.yml
+++ b/ansible_collections/arcgis/webadaptor/playbooks/install.yml
@@ -30,6 +30,10 @@
     tomcat_user: 'tomcat'
   become: true
   tasks:
+    - name: Install cryptography python library
+      become_user: root
+      ansible.builtin.pip:
+        name: cryptography
     - name: Create setups directory
       ansible.builtin.file:
         path: '{{ setups_directory }}/{{ arcgis_version }}'

--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -7,6 +7,12 @@ Supported ArcGIS Enterprise versions:
 * 11.4
 * 11.5
 
+Supported Operating Systems:
+
+* Red Hat Enterprise Linux 9
+* Ubuntu 22.04 LTS
+* SUSE Linux Enterprise Server 15
+
 Before running the template workflows:
 
 1. Configure the GitHub repository settings as described in the [Instructions](../README.md#instructions) section.

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -124,7 +124,7 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (rhel8\|rhel9\|ubuntu20\|ubuntu22\|ubuntu24\|sles15) | `string` | `"rhel8"` | no |
+| os | Operating system id (rhel9\|ubuntu22\|sles15) | `string` | `"rhel9"` | no |
 | portal_authorization_file_path | Local path of Portal for ArcGIS authorization file | `string` | n/a | yes |
 | portal_user_license_type_id | Portal for ArcGIS administrator user license type Id | `string` | `""` | no |
 | root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS | `string` | `null` | no |

--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -18,13 +18,13 @@ variable "aws_region" {
 }
 
 variable "os" {
-  description = "Operating system id (rhel8|rhel9|ubuntu20|ubuntu22|ubuntu24|sles15)"
+  description = "Operating system id (rhel9|ubuntu22|sles15)"
   type        = string
-  default     = "rhel8"
+  default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel8", "rhel9", "ubuntu20", "ubuntu22", "ubuntu24", "sles15"], var.os)
-    error_message = "Valid values for os variable are rhel8, rhel9, ubuntu20, ubuntu22, ubuntu24, and sles15."
+    condition     = contains(["rhel9", "ubuntu22", "sles15"], var.os)
+    error_message = "Valid values for os variable are rhel9, ubuntu22, and sles15."
   }
 }
 

--- a/aws/arcgis-enterprise-base-linux/image/README.md
+++ b/aws/arcgis-enterprise-base-linux/image/README.md
@@ -57,7 +57,7 @@ The template uses the following SSM parameters:
 | arcgis_web_adaptor_patches | File names of ArcGIS Web Adaptor patches to install | `string` | `[]` | no |
 | instance_type | EC2 instance type | `string` | `"6i.xlarge"` | no |
 | deployment_id | Deployment Id | `string` | `"enterprise-base-linux"` | no |
-| os | Operating system | `string` | `"rhel8"` | no |
+| os | Operating system | `string` | `"rhel9"` | no |
 | portal_web_context | Portal for ArcGIS web context | `string` | `"portal"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |
 | run_as_user | User account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store | `string` | `"arcgis"` | no |

--- a/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
@@ -19,13 +19,13 @@ variable "aws_region" {
 }
  
 variable "os" {
-  description = "Operating system Id (rhel8|rhel9|ubuntu20|ubuntu22|ubuntu24|sles15)"
+  description = "Operating system Id (rhel9|ubuntu22|sles15)"
   type        = string
-  default     = "rhel8"
+  default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel8", "rhel9", "ubuntu20", "ubuntu22", "ubuntu24", "sles15"], var.os)
-    error_message = "Valid values for os variable are rhel8, rhel9, ubuntu20, ubuntu22, ubuntu24, and sles15."
+    condition     = contains(["rhel9", "ubuntu22", "sles15"], var.os)
+    error_message = "Valid values for os variable are rhel9, ubuntu22, and sles15."
   }
 }
 

--- a/aws/arcgis-enterprise-base-windows/README.md
+++ b/aws/arcgis-enterprise-base-windows/README.md
@@ -7,6 +7,11 @@ Supported ArcGIS Enterprise versions:
 * 11.4
 * 11.5
   
+Supported Operating Systems:
+
+* Windows Server 2022
+* Windows Server 2025
+
 Before running the template workflows:
 
 1. Configure the GitHub repository settings as described in the [Instructions](../README.md#instructions) section.

--- a/aws/arcgis-enterprise-base-windows/application/README.md
+++ b/aws/arcgis-enterprise-base-windows/application/README.md
@@ -125,7 +125,7 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (windows2022) | `string` | `"windows2022"` | no |
+| os | Operating system id (windows2022\|windows2025) | `string` | `"windows2025"` | no |
 | portal_authorization_file_path | Local path of Portal for ArcGIS authorization file | `string` | n/a | yes |
 | portal_user_license_type_id | Portal for ArcGIS administrator user license type Id | `string` | `""` | no |
 | root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS | `string` | `null` | no |

--- a/aws/arcgis-enterprise-base-windows/application/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/application/variables.tf
@@ -18,9 +18,14 @@ variable "aws_region" {
 }
 
 variable "os" {
-  description = "Operating system id (windows2022)"
+  description = "Operating system id (windows2022|windows2025)"
   type        = string
-  default     = "windows2022"
+  default     = "windows2025"
+
+  validation {
+    condition     = contains(["windows2022", "windows2025"], var.os)
+    error_message = "Valid values for os variable are windows2022 and windows2025."
+  }
 }
 
 variable "site_id" {

--- a/aws/arcgis-enterprise-base-windows/image/README.md
+++ b/aws/arcgis-enterprise-base-windows/image/README.md
@@ -54,7 +54,7 @@ The template uses the following SSM parameters:
 | arcgis_web_adaptor_patches | File names of ArcGIS Web Adaptor patches to install | `string` | `[]` | no |
 | deployment_id | Deployment Id | `string` | `"enterprise-base-windows"` | no |
 | instance_type | EC2 instance type | `string` | `"6i.xlarge"` | no |
-| os | Operating system Id | `string` | `"windows2022"` | no |
+| os | Operating system Id | `string` | `"windows2025"` | no |
 | portal_web_context | Portal for ArcGIS web context | `string` | `"portal"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |
 | run_as_password | Password for the account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store. | `string` | `env("RUN_AS_PASSWORD")` | yes |

--- a/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-windows/image/variables.pkr.hcl
@@ -20,12 +20,12 @@ variable "aws_region" {
  
 variable "os" {
   description = "Operating system Id"
-  type = string
-  default = "windows2022"
+  type        = string
+  default     = "windows2025"
 
   validation {
-    condition     = contains(["windows2022"], var.os)
-    error_message = "Valid values for os variable are windows2022."
+    condition     = contains(["windows2022", "windows2025"], var.os)
+    error_message = "Valid values for os variable are windows2022 and windows2025."
   }
 }
 

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -9,6 +9,10 @@ Supported ArcGIS Server versions:
 * 11.4
 * 11.5
 
+Supported Linux distributions:
+
+* Red Hat Enterprise Linux 9
+
 Before running the template workflows:
 
 1. Configure the GitHub repository settings as described in the [Instructions](../README.md#instructions) section.

--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -111,7 +111,7 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (rhel8\|rhel9) | `string` | `"rhel8"` | no |
+| os | Operating system id (rhel8\|rhel9) | `string` | `"rhel9"` | no |
 | portal_org_id | ArcGIS Enterprise organization Id | `string` | `null` | no |
 | portal_password | Portal for ArcGIS user password | `string` | `null` | no |
 | portal_url | Portal for ArcGIS URL | `string` | `null` | no |

--- a/aws/arcgis-server-linux/application/variables.tf
+++ b/aws/arcgis-server-linux/application/variables.tf
@@ -103,11 +103,11 @@ variable "log_level" {
 variable "os" {
   description = "Operating system id (rhel8|rhel9)"
   type        = string
-  default     = "rhel8"
+  default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel8", "rhel9"], var.os)
-    error_message = "Valid values for os variable are rhel8, rhel9."
+    condition     = contains(["rhel9"], var.os)
+    error_message = "Valid values for os variable are rhel9."
   }
 }
 

--- a/aws/arcgis-server-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-server-linux/image/variables.pkr.hcl
@@ -53,13 +53,13 @@ variable "instance_type" {
 }
 
 variable "os" {
-  description = "Operating system Id (rhel8|rhel9)"
+  description = "Operating system Id (rhel9)"
   type        = string
-  default     = "rhel8"
+  default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel8", "rhel9"], var.os)
-    error_message = "Valid values for os variable are rhel8 and rhel9."
+    condition     = contains(["rhel9"], var.os)
+    error_message = "Valid values for os variable are rhel9."
   }
 }
 

--- a/aws/arcgis-site-core/automation-chef/variables.tf
+++ b/aws/arcgis-site-core/automation-chef/variables.tf
@@ -33,25 +33,17 @@ variable "chef_client_paths" {
   description = "Chef/CINC Client setup S3 keys by operating system"
   type        = map(any)
   default = {
+    windows2025 = {
+      path        = "cinc/cinc-18.7.6-1-x64.msi"
+      description = "Chef Client setup S3 key for Microsoft Windows Server 2022"
+    }
     windows2022 = {
       path        = "cinc/cinc-18.7.6-1-x64.msi"
       description = "Chef Client setup S3 key for Microsoft Windows Server 2022"
     }
-    ubuntu20 = {
-      path        = "cinc/cinc_18.7.6-1.ubuntu20.amd64.deb"
-      description = "Chef Client setup S3 key for Ubuntu 20.04 LTS"
-    }
     ubuntu22 = {
       path        = "cinc/cinc_18.7.6-1.ubuntu22.amd64.deb"
       description = "Chef Client setup S3 key for Ubuntu 22.04 LTS"
-    }
-    ubuntu22nvidia = {
-      path        = "cinc/cinc_18.7.6-1.ubuntu22.amd64.deb"
-      description = "Chef Client setup S3 key for Ubuntu 22.04 LTS"
-    }
-    rhel8 = {
-      path        = "cinc/cinc-18.7.6-1.el8.x86_64.rpm"
-      description = "Chef Client setup S3 key for Red Hat Enterprise Linux version 8"
     }
     rhel9 = {
       path        = "cinc/cinc-18.7.6-1.el9.x86_64.rpm"

--- a/aws/arcgis-site-core/infrastructure-core/variables.tf
+++ b/aws/arcgis-site-core/infrastructure-core/variables.tf
@@ -131,33 +131,18 @@ variable "images" {
       owner           = "amazon"
       description     = "Microsoft Windows Server 2022 Full Locale English AMI"
     }
-    ubuntu20 = {
-      ami_name_filter = "ubuntu/images/hvm-ssd/ubuntu-*20*-amd64-server-*"
-      owner           = "099720109477" # Canonical
-      description     = "Canonical, Ubuntu, 20.04 LTS, amd64 focal image"
+    windows2025 = {
+      ami_name_filter = "Windows_Server-2025-English-Full-Base-*"
+      owner           = "amazon"
+      description     = "Microsoft Windows Server 2025 Full Locale English AMI"
     }
     ubuntu22 = {
       ami_name_filter = "ubuntu/images/hvm-ssd/ubuntu-*22*-amd64-server-*"
       owner           = "099720109477" # Canonical
       description     = "Canonical, Ubuntu, 22.04 LTS, amd64 focal image"
     }
-    ubuntu22nvidia = {
-      ami_name_filter = "NVIDIA GPU Cloud VMI Base 2024.10.1 x86_64-*"
-      owner           = "679593333241" # NVIDIA 
-      description     = "NVIDIA GPU Cloud VMI Base 2024.10.1 x86_64"
-    }
-    ubuntu24 = {
-      ami_name_filter = "ubuntu/images/hvm-ssd-gp3/ubuntu-*24*-amd64-server-*"
-      owner           = "099720109477" # Canonical
-      description     = "Canonical, Ubuntu, 24.04 LTS, amd64 focal image"
-    }
-    rhel8 = {
-      ami_name_filter = "RHEL-8.9.0_HVM-*-x86_64-*-Hourly2-GP3"
-      owner           = "309956199498" # Red Hat
-      description     = "Red Hat Enterprise Linux version 8 (HVM), EBS General Purpose (SSD) Volume Type"
-    }
     rhel9 = {
-      ami_name_filter = "RHEL-9.3.0_HVM-*-x86_64-*-Hourly2-GP3"
+      ami_name_filter = "RHEL-9.5.0_HVM-*-x86_64-*-Hourly2-GP3"
       owner           = "309956199498" # Red Hat
       description     = "Red Hat Enterprise Linux version 9 (HVM), EBS General Purpose (SSD) Volume Type"
     }

--- a/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
@@ -18,7 +18,7 @@
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
-  "os": "rhel8",
+  "os": "rhel9",
   "portal_authorization_file_path": "~/config/authorization/11.5/portal_115.json",
   "portal_user_license_type_id": "creatorUT",
   "root_cert_file_path": null,

--- a/config/aws/arcgis-enterprise-base-linux/image.vars.json
+++ b/config/aws/arcgis-enterprise-base-linux/image.vars.json
@@ -12,7 +12,7 @@
   "arcgis_web_adaptor_patches": [],
   "deployment_id": "enterprise-base-linux",
   "instance_type": "m7i.2xlarge",
-  "os": "rhel8",
+  "os": "rhel9",
   "portal_web_context": "portal",
   "root_volume_size": 100,
   "run_as_user": "arcgis",

--- a/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
@@ -18,7 +18,7 @@
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
-  "os": "windows2022",
+  "os": "windows2025",
   "portal_authorization_file_path": "~/config/authorization/11.5/portal_115.json",
   "portal_user_license_type_id": "creatorUT",
   "root_cert_file_path": null,

--- a/config/aws/arcgis-enterprise-base-windows/image.vars.json
+++ b/config/aws/arcgis-enterprise-base-windows/image.vars.json
@@ -12,7 +12,7 @@
   "arcgis_web_adaptor_patches": [],
   "deployment_id": "enterprise-base-windows",
   "instance_type": "m7i.2xlarge",
-  "os": "windows2022",
+  "os": "windows2025",
   "portal_web_context": "portal",
   "root_volume_size": 100,
   "run_as_username": "arcgis",

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -9,7 +9,7 @@
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
-  "os": "rhel8",
+  "os": "rhel9",
   "portal_org_id": null,
   "portal_url": null,
   "root_cert_file_path": null,

--- a/config/aws/arcgis-server-linux/image.vars.json
+++ b/config/aws/arcgis-server-linux/image.vars.json
@@ -5,7 +5,7 @@
   "arcgis_version": "11.5",
   "deployment_id": "server-linux",
   "instance_type": "m7i.2xlarge",
-  "os": "rhel8",
+  "os": "rhel9",
   "root_volume_size": 100,
   "run_as_user": "arcgis",
   "server_web_context": "arcgis",

--- a/config/aws/arcgis-site-core/automation-chef.tfvars.json
+++ b/config/aws/arcgis-site-core/automation-chef.tfvars.json
@@ -1,10 +1,6 @@
 {
   "arcgis_cookbooks_path": "cookbooks/arcgis-5.2.0-cookbooks.tar.gz",
   "chef_client_paths": {
-    "rhel8": {
-      "description": "Chef Client setup S3 key for Red Hat Enterprise Linux version 8",
-      "path": "cinc/cinc-18.7.6-1.el8.x86_64.rpm"
-    },
     "rhel9": {
       "description": "Chef Client setup S3 key for Red Hat Enterprise Linux version 9",
       "path": "cinc/cinc-18.7.6-1.el9.x86_64.rpm"
@@ -13,19 +9,15 @@
       "description": "Chef Client setup S3 key for SUSE Linux Enterprise Server 15",
       "path": "cinc/cinc-18.7.6-1.sles15.x86_64.rpm"
     },
-    "ubuntu20": {
-      "description": "Chef Client setup S3 key for Ubuntu 20.04 LTS",
-      "path": "cinc/cinc_18.7.6-1.ubuntu20.amd64.deb"
-    },
     "ubuntu22": {
       "description": "Chef Client setup S3 key for Ubuntu 22.04 LTS",
       "path": "cinc/cinc_18.7.6-1.ubuntu22.amd64.deb"
     },
-    "ubuntu22nvidia": {
-      "description": "Chef Client setup S3 key for Ubuntu 22.04 LTS",
-      "path": "cinc/cinc_18.7.6-1.ubuntu22.amd64.deb"
-    },
     "windows2022": {
+      "description": "Chef Client setup S3 key for Microsoft Windows Server 2022",
+      "path": "cinc/cinc-18.7.6-1-x64.msi"
+    },
+    "windows2025": {
       "description": "Chef Client setup S3 key for Microsoft Windows Server 2022",
       "path": "cinc/cinc-18.7.6-1-x64.msi"
     }

--- a/config/aws/arcgis-site-core/infrastructure-core.tfvars.json
+++ b/config/aws/arcgis-site-core/infrastructure-core.tfvars.json
@@ -34,13 +34,8 @@
   "site_id": "arcgis",
   "vpc_cidr_block": "10.0.0.0/16",
   "images": {
-    "rhel8": {
-      "ami_name_filter": "RHEL-8.9.0_HVM-*-x86_64-*-Hourly2-GP3",
-      "description": "Red Hat Enterprise Linux version 8 (HVM), EBS General Purpose (SSD) Volume Type",
-      "owner": "309956199498"
-    },
     "rhel9": {
-      "ami_name_filter": "RHEL-9.3.0_HVM-*-x86_64-*-Hourly2-GP3",
+      "ami_name_filter": "RHEL-9.5.0_HVM-*-x86_64-*-Hourly2-GP3",
       "description": "Red Hat Enterprise Linux version 9 (HVM), EBS General Purpose (SSD) Volume Type",
       "owner": "309956199498"
     },
@@ -49,24 +44,19 @@
       "description": "SUSE Linux Enterprise Server 15 (HVM, 64-bit, SSD-Backed)",
       "owner": "013907871322"
     },
-    "ubuntu20": {
-      "ami_name_filter": "ubuntu/images/hvm-ssd/ubuntu-*20*-amd64-server-*",
-      "description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image",
-      "owner": "099720109477"
-    },
     "ubuntu22": {
       "ami_name_filter": "ubuntu/images/hvm-ssd/ubuntu-*22*-amd64-server-*",
       "description": "Canonical, Ubuntu, 22.04 LTS, amd64 focal image",
       "owner": "099720109477"
     },
-    "ubuntu22nvidia": {
-      "ami_name_filter" : "NVIDIA GPU Cloud VMI Base 2024.10.1 x86_64-*",
-      "description" : "NVIDIA GPU Cloud VMI Base 2024.10.1 x86_64",
-      "owner" : "679593333241"
-    },    
     "windows2022": {
       "ami_name_filter": "Windows_Server-2022-English-Full-Base-*",
       "description": "Microsoft Windows Server 2022 Full Locale English AMI",
+      "owner": "amazon"
+    },
+    "windows2025": {
+      "ami_name_filter": "Windows_Server-2025-English-Full-Base-*",
+      "description": "Microsoft Windows Server 2025 Full Locale English AMI",
       "owner": "amazon"
     }
   }


### PR DESCRIPTION
The fix:

* Adds support for RHEL 9 to arcgis-enterprise-base-linux and arcgis-server-linux templates and sets the default OS to "rhel9".
* Adds support for Windows Server 2025 to arcgis-enterprise-base-windows template and sets the default OS to "windows2025".
* Drops support For RHEL8, Ubuntu 20.04, and Ubuntu 24.04.
* Adds "Supported Operating Systems" section to the templates' READMEs.