### PR TITLE
#238 Scripts for managing IAM policies

### DIFF
--- a/aws/iam-policies/README.md
+++ b/aws/iam-policies/README.md
@@ -1,35 +1,47 @@
 # IAM Policies for GitHub Actions Workflows
 
-User managed IAM policies for GitHub Actions workflows.
+The directory contains user managed IAM policies for the GitHub Actions workflows.
 
 > The ARNs in the policy documents must be updated to use the correct ARN format for the region where the policies will be used. In particular, in AWS GovCloud (US) Regions, ARNs have an identifier that is different from the one in other standard AWS Regions. For all other standard regions, ARNs begin with: `arn:aws`. In the AWS GovCloud (US) Regions, ARNs begin with:`arn:aws-us-gov`.
 
-## Creating IAM Policies using AWS CLI
+> The script requires AWS CLI to be installed and configured with the credentials of an IAM user that has permissions to create IAM policies.
+
+## Creating IAM Policies
+
+Use create-iam-policies.sh script create IAM policies for the GitHub Action workflows using the JSON policy documents.
+
+Allow execution of the scripts in this directory:
 
 ```shell
-aws iam create-policy --policy-name ArcGISEnterpriseApplication --policy-document file://ArcGISEnterpriseApplication.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for ArcGIS Enterprise applications management workflows"
-
-aws iam create-policy --policy-name ArcGISEnterpriseDestroy --policy-document file://ArcGISEnterpriseDestroy.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for destroying resources created by ArcGIS Enterprise infrastructure and application management workflows"
-
-aws iam create-policy --policy-name ArcGISEnterpriseImage --policy-document file://ArcGISEnterpriseImage.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for creating EC2 AMIs for ArcGIS Enterprise deployments"
-
-aws iam create-policy --policy-name ArcGISEnterpriseInfrastructure --policy-document file://ArcGISEnterpriseInfrastructure.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for ArcGIS Enterprise infrastructure management workflows"
-
-aws iam create-policy --policy-name ArcGISSiteCore --policy-document file://ArcGISSiteCore.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-core-aws workflow"
-
-aws iam create-policy --policy-name ArcGISSiteCoreDestroy --policy-document file://ArcGISSiteCoreDestroy.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-core-aws-destroy workflow" 
-
-aws iam create-policy --policy-name ArcGISSiteK8sCluster --policy-document file://ArcGISSiteK8sCluster.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-k8s-cluster-aws workflow"
-
-aws iam create-policy --policy-name ArcGISSiteK8sClusterDestroy --policy-document file://ArcGISSiteK8sClusterDestroy.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-k8s-cluster-aws-destroy workflow"
-
-aws iam create-policy --policy-name ArcGISEnterpriseK8s --policy-document file://ArcGISEnterpriseK8s.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for enterprise-k8s-aws-* workflows"
-
-aws iam create-policy --policy-name TerraformBackend --policy-document file://TerraformBackend.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for Terraform S3 backend"
+chmod +x *.sh
 ```
 
-Attach the required policies to the IAM user used to run the GitHub Actions workflows.
+Run the script to create the IAM policies:
 
 ```shell
-aws iam attach-user-policy --policy-arn <policy ARN> --user-name gitops
+./create-iam-policies.sh
+```
+
+## Updating IAM Policies
+
+Use update-iam-policies.sh script to create new versions of the IAM policies created by create-iam-policies.sh script using the updated JSON policy documents:
+
+```shell
+./update-iam-policies.sh
+```
+
+## Deleting the IAM Policies
+
+Use delete-iam-policies.sh script to delete the IAM policies created by create-iam-policies.sh script:
+
+```shell
+./delete-iam-policies.sh
+```
+
+## Attaching IAM Policies to the IAM User
+
+To attach the required policies to the IAM user used to run the GitHub Actions workflows you can use the following command:
+
+```shell
+aws iam attach-user-policy --policy-arn <policy ARN> --user-name <IAM user name>
 ```

--- a/aws/iam-policies/create-iam-policies.sh
+++ b/aws/iam-policies/create-iam-policies.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2025 Esri
+#
+# Licensed under the Apache License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script creates IAM policies for the GitHub Action workflows using the JSON policy documents
+# located in the same directory as this script.
+
+aws iam create-policy --policy-name ArcGISEnterpriseApplication --policy-document file://ArcGISEnterpriseApplication.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for ArcGIS Enterprise applications management workflows" --output text
+aws iam create-policy --policy-name ArcGISEnterpriseDestroy --policy-document file://ArcGISEnterpriseDestroy.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for destroying resources created by ArcGIS Enterprise infrastructure and application management workflows" --output text
+aws iam create-policy --policy-name ArcGISEnterpriseImage --policy-document file://ArcGISEnterpriseImage.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for creating EC2 AMIs for ArcGIS Enterprise deployments" --output text
+aws iam create-policy --policy-name ArcGISEnterpriseInfrastructure --policy-document file://ArcGISEnterpriseInfrastructure.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for ArcGIS Enterprise infrastructure management workflows" --output text
+aws iam create-policy --policy-name ArcGISEnterpriseK8s --policy-document file://ArcGISEnterpriseK8s.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for ArcGIS Enterprise on Kubernetes workflows" --output text
+aws iam create-policy --policy-name ArcGISSiteCore --policy-document file://ArcGISSiteCore.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-core-aws workflow" --output text
+aws iam create-policy --policy-name ArcGISSiteCoreDestroy --policy-document file://ArcGISSiteCoreDestroy.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-core-aws-destroy workflow" --output text
+aws iam create-policy --policy-name ArcGISSiteK8sCluster --policy-document file://ArcGISSiteK8sCluster.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-k8s-cluster-aws workflow" --output text
+aws iam create-policy --policy-name ArcGISSiteK8sClusterDestroy --policy-document file://ArcGISSiteK8sClusterDestroy.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for site-k8s-cluster-aws-destroy workflow" --output text
+aws iam create-policy --policy-name TerraformBackend --policy-document file://TerraformBackend.json --tags Key=ArcGISSiteId,Value=arcgis --description "The policy for Terraform S3 backend" --output text

--- a/aws/iam-policies/delete-iam-policies.sh
+++ b/aws/iam-policies/delete-iam-policies.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2025 Esri
+#
+# Licensed under the Apache License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script deletes IAM policies created by create-iam-policies.sh script.
+
+delete_iam_policy() {
+    local policy_arn="$1"
+
+    if [[ -z "$policy_arn" ]]; then
+        echo "Usage: delete_iam_policy <policy-arn>"
+        return 1
+    fi
+
+    echo "Fetching policy versions for: $policy_arn"
+    local versions
+    versions=$(aws iam list-policy-versions \
+        --policy-arn "$policy_arn" \
+        --query 'Versions[?IsDefaultVersion==`false`].VersionId' \
+        --output text)
+
+    for version in $versions; do
+        echo "Deleting non-default version: $version"
+        aws iam delete-policy-version --policy-arn "$policy_arn" --version-id "$version"
+    done
+
+    echo "Deleting the policy itself..."
+    aws iam delete-policy --policy-arn "$policy_arn"
+
+    echo "Policy deleted: $policy_arn"
+}
+
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseApplication
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseDestroy
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseImage
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseInfrastructure
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseK8s
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteCore
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteCoreDestroy
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteK8sCluster
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteK8sClusterDestroy
+delete_iam_policy arn:aws:iam::$AWS_ACCOUNT_ID:policy/TerraformBackend

--- a/aws/iam-policies/update-iam-policies.sh
+++ b/aws/iam-policies/update-iam-policies.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2025 Esri
+#
+# Licensed under the Apache License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script updates IAM policies created by create-iam-policies.sh script using the JSON policy documents
+# located in the same directory as this script.
+
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseApplication --policy-document file://ArcGISEnterpriseApplication.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseDestroy --policy-document file://ArcGISEnterpriseDestroy.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseImage --policy-document file://ArcGISEnterpriseImage.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseInfrastructure --policy-document file://ArcGISEnterpriseInfrastructure.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISEnterpriseK8s --policy-document file://ArcGISEnterpriseK8s.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteCore --policy-document file://ArcGISSiteCore.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteCoreDestroy --policy-document file://ArcGISSiteCoreDestroy.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteK8sCluster --policy-document file://ArcGISSiteK8sCluster.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ArcGISSiteK8sClusterDestroy --policy-document file://ArcGISSiteK8sClusterDestroy.json --set-as-default --output text
+aws iam create-policy-version --policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/TerraformBackend --policy-document file://TerraformBackend.json --set-as-default --output text


### PR DESCRIPTION
The fix adds three new scripts for managing IAM policies:

* *create-iam-policies.sh* script creates IAM policies for the GitHub Action workflows using the JSON policy documents.
* *update-iam-policies.sh* script creates new versions of the IAM policies created by create-iam-policies.sh script.
* *delete-iam-policies.sh* script deletes the IAM policies created by create-iam-policies.sh script.