### PR TITLE
#172 Grant ACR access to the Key Vault using RBAC

### DIFF
--- a/azure/arcgis-site-core/k8s-cluster/modules/container-registry/main.tf
+++ b/azure/arcgis-site-core/k8s-cluster/modules/container-registry/main.tf
@@ -103,7 +103,7 @@ resource "azurerm_container_registry_credential_set" "credential_set" {
 resource "azurerm_role_assignment" "pull_through_cache" {
   principal_id                     = azurerm_container_registry_credential_set.credential_set.identity[0].principal_id
   role_definition_name             = "Key Vault Secrets User"
-  scope                            =  module.site_core_info.vault_id
+  scope                            = module.site_core_info.vault_id
   skip_service_principal_aad_check = true
 }
 


### PR DESCRIPTION
Policy-based access control is not enabled on the site's Key Vault anymore. 
Use RBAC to grant ACR access to the key vault secrets.