### PR TITLE
#248 Clarify instructions for terraform_command=plan

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -104,10 +104,6 @@ Required IAM policies:
 * TerraformBackend
 * ArcGISEnterpriseApplication
 
-Inputs:
-
-* terraform_command - Terraform command (apply|plan)
-
 Outputs:
 
 * arcgis_portal_url - Portal for ArcGIS URL

--- a/aws/arcgis-notebook-server-linux/README.md
+++ b/aws/arcgis-notebook-server-linux/README.md
@@ -73,6 +73,8 @@ Instructions:
 4. Commit the changes to the Git branch and push the branch to GitHub.
 5. Run the notebook-server-linux-aws-infrastructure workflow using the branch.
 
+> When updating the infrastructure, first run the workflow with terraform_command=plan before running it with terraform_command=apply and check the logs to make sure that Terraform does not destroy and recreate critical AWS resources such as EC2 instances.
+
 ### 3. Configure Applications
 
 GitHub Actions workflow **notebook-server-linux-aws-application** configures or upgrades ArcGIS Notebook Server on EC2 instances.
@@ -83,10 +85,6 @@ Required IAM policies:
 
 * TerraformBackend
 * ArcGISEnterpriseApplication
-
-Inputs:
-
-* terraform_command - Terraform command (apply|plan)
 
 Outputs:
 

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -107,10 +107,6 @@ Required IAM policies:
 * TerraformBackend
 * ArcGISEnterpriseApplication
 
-Inputs:
-
-* terraform_command - Terraform command (apply|plan)
-
 Outputs:
 
 * arcgis_server_url - ArcGIS Server URL

--- a/azure/arcgis-enterprise-base-windows/README.md
+++ b/azure/arcgis-enterprise-base-windows/README.md
@@ -75,6 +75,10 @@ Required service principal roles:
 
 * Owner role at the subscription scope
 
+Workflow Inputs:
+
+* terraform_command - Terraform command (apply|plan)
+
 Instructions:
 
 1. If required, change "vm_size" and "os_disk_size" properties to the required VM size and OS disk size (in GB).


### PR DESCRIPTION
terraform_command input is only available for the "infrastructure" workflows. The PR updates READMEs of the templates to clarify the use of terraform_command=plan.