### PR TITLE
#255 Add support for Ubuntu 24.04 to the Linux templates

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -12,6 +12,7 @@ Supported Operating Systems:
 
 * Red Hat Enterprise Linux 9
 * Ubuntu 22.04 LTS
+* Ubuntu 24.04 LTS
 
 Before running the template workflows:
 

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -131,7 +131,7 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (rhel9\|ubuntu22) | `string` | `"rhel9"` | no |
+| os | Operating system id (rhel9\|ubuntu22\|ubuntu24) | `string` | `"rhel9"` | no |
 | portal_authorization_file_path | Local path of Portal for ArcGIS authorization file | `string` | n/a | yes |
 | portal_user_license_type_id | Portal for ArcGIS administrator user license type Id | `string` | `""` | no |
 | root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS | `string` | `null` | no |

--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -18,13 +18,13 @@ variable "aws_region" {
 }
 
 variable "os" {
-  description = "Operating system id (rhel9|ubuntu22)"
+  description = "Operating system id (rhel9|ubuntu22|ubuntu24)"
   type        = string
   default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel9", "ubuntu22"], var.os)
-    error_message = "Valid values for os variable are rhel9 and ubuntu22."
+    condition     = contains(["rhel9", "ubuntu22", "ubuntu24"], var.os)
+    error_message = "Valid values for os variable are rhel9, ubuntu22, and ubuntu24."
   }
 }
 

--- a/aws/arcgis-enterprise-base-linux/image/README.md
+++ b/aws/arcgis-enterprise-base-linux/image/README.md
@@ -57,7 +57,7 @@ The template uses the following SSM parameters:
 | arcgis_web_adaptor_patches | File names of ArcGIS Web Adaptor patches to install | `string` | `[]` | no |
 | instance_type | EC2 instance type | `string` | `"6i.xlarge"` | no |
 | deployment_id | Deployment Id | `string` | `"enterprise-base-linux"` | no |
-| os | Operating system | `string` | `"rhel9"` | no |
+| os | Operating system Id (rhel9\|ubuntu22\|ubuntu24) | `string` | `"rhel9"` | no |
 | portal_web_context | Portal for ArcGIS web context | `string` | `"portal"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |
 | run_as_user | User account used to run ArcGIS Server, Portal for ArcGIS, and ArcGIS Data Store | `string` | `"arcgis"` | no |

--- a/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/variables.pkr.hcl
@@ -19,13 +19,13 @@ variable "aws_region" {
 }
  
 variable "os" {
-  description = "Operating system Id (rhel9|ubuntu22)"
+  description = "Operating system Id (rhel9|ubuntu22|ubuntu24)"
   type        = string
   default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel9", "ubuntu22"], var.os)
-    error_message = "Valid values for os variable are rhel9 and ubuntu22."
+    condition     = contains(["rhel9", "ubuntu22", "ubuntu24"], var.os)
+    error_message = "Valid values for os variable are rhel9, ubuntu22, and ubuntu24."
   }
 }
 

--- a/aws/arcgis-notebook-server-linux/README.md
+++ b/aws/arcgis-notebook-server-linux/README.md
@@ -11,6 +11,7 @@ Supported ArcGIS Notebook Server versions:
 Supported Operating Systems:
 
 * Red Hat Enterprise Linux 9
+* Ubuntu 22.04 LTS
 * Ubuntu 24.04 LTS
 
 Before running the template workflows:

--- a/aws/arcgis-notebook-server-linux/application/README.md
+++ b/aws/arcgis-notebook-server-linux/application/README.md
@@ -62,7 +62,7 @@ The module reads the following SSM parameters:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 6.0 |
+| aws | ~> 6.10 |
 
 ## Modules
 
@@ -120,7 +120,7 @@ The module reads the following SSM parameters:
 | log_level | ArcGIS Notebook Server log level | `string` | `"WARNING"` | no |
 | notebook_server_authorization_file_path | Local path of ArcGIS Notebook Server authorization file | `string` | n/a | yes |
 | notebook_server_authorization_options | Additional ArcGIS Notebook Server software authorization command line options | `string` | `""` | no |
-| os | Operating system id (rhel9\|ubuntu22) | `string` | `"rhel9"` | no |
+| os | Operating system id (rhel9\|ubuntu22\|ubuntu24) | `string` | `"rhel9"` | no |
 | portal_org_id | ArcGIS Enterprise organization Id | `string` | `null` | no |
 | portal_password | Portal for ArcGIS user password | `string` | `null` | no |
 | portal_url | Portal for ArcGIS URL | `string` | `null` | no |

--- a/aws/arcgis-notebook-server-linux/application/variables.tf
+++ b/aws/arcgis-notebook-server-linux/application/variables.tf
@@ -142,13 +142,13 @@ variable "notebook_server_authorization_options" {
 }
 
 variable "os" {
-  description = "Operating system id (rhel9|ubuntu22)"
+  description = "Operating system id (rhel9|ubuntu22|ubuntu24)"
   type        = string
   default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel9", "ubuntu22"], var.os)
-    error_message = "Valid values for os variable are rhel9 and ubuntu22."
+    condition     = contains(["rhel9", "ubuntu22", "ubuntu24"], var.os)
+    error_message = "Valid values for os variable are rhel9, ubuntu22, and ubuntu24."
   }
 }
 

--- a/aws/arcgis-notebook-server-linux/image/README.md
+++ b/aws/arcgis-notebook-server-linux/image/README.md
@@ -65,7 +65,7 @@ The template writes the following SSM parameters:
 | deployment_id | Deployment Id | `string` | `"notebook-server-linux"` | no |
 | instance_type | EC2 instance type | `string` | `"m6i.2xlarge"` | no |
 | license_level | ArcGIS Notebook Server license level | `string` | `"standard"` | no |
-| os | Operating system | `string` | `"rhel9"` | no |
+| os | Operating system Id (rhel9\|ubuntu22\|ubuntu24) | `string` | `"rhel9"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `128` | no |
 | run_as_user | User account used to run ArcGIS Notebook Server | `string` | `"arcgis"` | no |
 | notebook_server_web_context | ArcGIS Notebook Server web context | `string` | `"notebooks"` | no |

--- a/aws/arcgis-notebook-server-linux/image/scripts/ubuntu24.sh
+++ b/aws/arcgis-notebook-server-linux/image/scripts/ubuntu24.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Copyright 2025 Esri
+#
+# Licensed under the Apache License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script initializes an Ubuntu 24.04 instance for ArcGIS Notebook Server: 
+#
+# * Installs Docker CE (https://docs.docker.com/engine/install/ubuntu/)
+# * If gpu_ready attribute is `true`, the script also installs:
+# * * Development Tools
+# * * Compute-only NVIDIA Driver open kernel modules (https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/)
+# * * CUDA Toolkit (https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)
+# * * NVIDIA Container Toolkit (https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+
+JSON_ATTRIBUTES_PARAMETER='<json_attributes_parameter>'
+DOCKER_CE_PACKAGE_VERSION='5:28.5.2-1~ubuntu.24.04~noble'
+DOCKER_CE_CLI_PACKAGE_VERSION='5:28.5.2-1~ubuntu.24.04~noble'
+
+# Get the script input parameters in JSON format from SSM Parameter Store
+attributes=$(aws ssm get-parameter --name $JSON_ATTRIBUTES_PARAMETER --query 'Parameter.Value' --with-decryption --output text)
+
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to retrieve '$JSON_ATTRIBUTES_PARAMETER' SSM parameter."
+  exit 1
+fi
+
+sudo apt-get install -y jq
+
+# Get the parameters from the JSON string
+GPU_READY=$(echo $attributes | jq -r '.gpu_ready')
+
+# Add Docker's official GPG key:
+sudo apt-get update -y
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update -y
+
+# Install Docker CE
+sudo apt-get install -y docker-ce=$DOCKER_CE_PACKAGE_VERSION docker-ce-cli=$DOCKER_CE_CLI_PACKAGE_VERSION containerd.io docker-buildx-plugin docker-compose-plugin
+
+if [ "$GPU_READY" == "true" ]; then
+  # Install gcc
+  sudo apt-get install -y build-essential gcc-12
+
+  # Install NVIDIA Driver
+  sudo apt-get install -y linux-headers-$(uname -r)
+
+  cd /tmp
+  wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+  sudo dpkg -i cuda-keyring_1.1-1_all.deb
+  sudo apt-get update -y
+
+  sudo apt-get install -y libnvidia-compute-575 nvidia-dkms-575-open nvidia-utils-575
+
+  # Install CUDA Toolkit
+  sudo apt-get install -y cuda-toolkit nvidia-gds
+
+  # Install NVIDIA Container Toolkit
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  sudo apt-get install -y nvidia-container-toolkit 
+  sudo nvidia-ctk runtime configure --runtime=docker 
+fi

--- a/aws/arcgis-notebook-server-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-notebook-server-linux/image/variables.pkr.hcl
@@ -70,13 +70,13 @@ variable "license_level" {
 }
 
 variable "os" {
-  description = "Operating system Id (rhel9|ubuntu22)"
+  description = "Operating system Id (rhel9|ubuntu22|ubuntu24)"
   type        = string
   default     = "rhel9"
 
   validation {
-    condition     = contains(["rhel9", "ubuntu22"], var.os)
-    error_message = "Valid values for os variable are rhel9 and ubuntu22."
+    condition     = contains(["rhel9", "ubuntu22", "ubuntu24"], var.os)
+    error_message = "Valid values for os variable are rhel9, ubuntu22, and ubuntu24."
   }
 }
 

--- a/aws/arcgis-site-core/automation-chef/README.md
+++ b/aws/arcgis-site-core/automation-chef/README.md
@@ -41,7 +41,7 @@ Before using the module, the repository S3 bucket must be created by infrastruct
 
 | Name | Version |
 |------|---------|
-| aws | ~> 6.0 |
+| aws | ~> 6.10 |
 
 ## Modules
 
@@ -67,8 +67,8 @@ Before using the module, the repository S3 bucket must be created by infrastruct
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| arcgis_cookbooks_path | S3 repository key of Chef cookbooks for ArcGIS distribution archive in the repository bucket | `string` | `"cookbooks/arcgis-5.2.0-cookbooks.tar.gz"` | no |
+| arcgis_cookbooks_path | S3 repository key of Chef cookbooks for ArcGIS distribution archive in the repository bucket | `string` | `"cookbooks/arcgis-5.3.0-cookbooks.tar.gz"` | no |
 | aws_region | AWS region Id | `string` | n/a | yes |
-| chef_client_paths | Chef/CINC Client setup S3 keys by operating system | `map(any)` | ```{ "rhel9": { "description": "Chef Client setup S3 key for Red Hat Enterprise Linux version 9", "path": "cinc/cinc-18.7.6-1.el9.x86_64.rpm" }, "ubuntu22": { "description": "Chef Client setup S3 key for Ubuntu 22.04 LTS", "path": "cinc/cinc_18.7.6-1.ubuntu22.amd64.deb" }, "windows2022": { "description": "Chef Client setup S3 key for Microsoft Windows Server 2022", "path": "cinc/cinc-18.7.6-1-x64.msi" }, "windows2025": { "description": "Chef Client setup S3 key for Microsoft Windows Server 2022", "path": "cinc/cinc-18.7.6-1-x64.msi" } }``` | no |
+| chef_client_paths | Chef/CINC Client setup S3 keys by operating system | `map(any)` | ```{ "rhel9": { "description": "Chef Client setup S3 key for Red Hat Enterprise Linux version 9", "path": "cinc/cinc-18.8.54-1.el9.x86_64.rpm" }, "ubuntu22": { "description": "Chef Client setup S3 key for Ubuntu 22.04 LTS", "path": "cinc/cinc_18.8.54-1.ubuntu22.amd64.deb" }, "ubuntu24": { "description": "Chef Client setup S3 key for Ubuntu 24.04 LTS", "path": "cinc/cinc_18.8.54-1.ubuntu24.amd64.deb" }, "windows2022": { "description": "Chef Client setup S3 key for Microsoft Windows Server 2022", "path": "cinc/cinc-18.8.54-1-x64.msi" }, "windows2025": { "description": "Chef Client setup S3 key for Microsoft Windows Server 2022", "path": "cinc/cinc-18.8.54-1-x64.msi" } }``` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis"` | no |
 <!-- END_TF_DOCS -->

--- a/aws/arcgis-site-core/automation-chef/manifests/automation-chef-files.json
+++ b/aws/arcgis-site-core/automation-chef/manifests/automation-chef-files.json
@@ -12,6 +12,11 @@
           "subfolder": "cinc",
           "sha256": "17028DCFE23E57A43D2FFFD490D696BFBCD47F796DD9FE302AC0515B0D4218EC"
         },
+        "cinc_18.8.54-1.ubuntu24.amd64.deb": {
+          "url": "https://downloads.cinc.sh/files/stable/cinc/18.8.54/ubuntu/24.04/cinc_18.8.54-1_amd64.deb",
+          "subfolder": "cinc",
+          "sha256": "B6908A59302337C2DBC959A78C40128821531312385398032EB753A21738C3DF"
+        },
         "cinc-18.8.54-1.el9.x86_64.rpm": {
           "url": "https://downloads.cinc.sh/files/stable/cinc/18.8.54/el/9/cinc-18.8.54-1.el9.x86_64.rpm",
           "subfolder": "cinc",

--- a/aws/arcgis-site-core/automation-chef/variables.tf
+++ b/aws/arcgis-site-core/automation-chef/variables.tf
@@ -45,6 +45,10 @@ variable "chef_client_paths" {
       path        = "cinc/cinc_18.8.54-1.ubuntu22.amd64.deb"
       description = "Chef Client setup S3 key for Ubuntu 22.04 LTS"
     }
+    ubuntu24 = {
+      path        = "cinc/cinc_18.8.54-1.ubuntu24.amd64.deb"
+      description = "Chef Client setup S3 key for Ubuntu 24.04 LTS"
+    }
     rhel9 = {
       path        = "cinc/cinc-18.8.54-1.el9.x86_64.rpm"
       description = "Chef Client setup S3 key for Red Hat Enterprise Linux version 9"

--- a/aws/arcgis-site-core/infrastructure-core/README.md
+++ b/aws/arcgis-site-core/infrastructure-core/README.md
@@ -36,7 +36,7 @@ Ids of the created AWS resources are stored in SSM parameters:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 6.0 |
+| aws | ~> 6.10 |
 
 ## Resources
 
@@ -94,8 +94,8 @@ Ids of the created AWS resources are stored in SSM parameters:
 | availability_zones | AWS availability zones (if the list contains less that two elements, the first two available availability zones in the AWS region will be used.) | `list(string)` | `[]` | no |
 | aws_region | AWS region Id | `string` | n/a | yes |
 | gateway_vpc_endpoints | List of gateway VPC endpoints to create | `list(string)` | ```[ "dynamodb", "s3" ]``` | no |
-| iam_role_policies | IAM role policies to attach to the ArcGIS Enterprise IAM role | `list(string)` | ```[ "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy", "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientFullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy" ]``` | no |
-| images | AMI search filters by operating  system | `map(any)` | ```{ "rhel9": { "ami_name_filter": "RHEL-9.5.0_HVM-*-x86_64-*-Hourly2-GP3", "description": "Red Hat Enterprise Linux version 9 (HVM), EBS General Purpose (SSD) Volume Type", "owner": "309956199498" }, "ubuntu22": { "ami_name_filter": "ubuntu/images/hvm-ssd/ubuntu-*22*-amd64-server-*", "description": "Canonical, Ubuntu, 22.04 LTS, amd64 focal image", "owner": "099720109477" }, "windows2022": { "ami_name_filter": "Windows_Server-2022-English-Full-Base-*", "description": "Microsoft Windows Server 2022 Full Locale English AMI", "owner": "amazon" }, "windows2025": { "ami_name_filter": "Windows_Server-2025-English-Full-Base-*", "description": "Microsoft Windows Server 2025 Full Locale English AMI", "owner": "amazon" } }``` | no |
+| iam_role_policies | IAM role policies to attach to the ArcGIS Enterprise IAM role | `list(string)` | ```[ "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AmazonSQSFullAccess", "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy", "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientFullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy" ]``` | no |
+| images | AMI search filters by operating  system | `map(any)` | ```{ "rhel9": { "ami_name_filter": "RHEL-9.5.0_HVM-*-x86_64-*-Hourly2-GP3", "description": "Red Hat Enterprise Linux version 9 (HVM), EBS General Purpose (SSD) Volume Type", "owner": "309956199498" }, "ubuntu22": { "ami_name_filter": "ubuntu/images/hvm-ssd/ubuntu-*22*-amd64-server-*", "description": "Canonical, Ubuntu, 22.04 LTS, amd64 focal image", "owner": "099720109477" }, "ubuntu24": { "ami_name_filter": "ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-amd64-server-*", "description": "Canonical, Ubuntu, 24.04 LTS, amd64 focal image", "owner": "099720109477" }, "windows2022": { "ami_name_filter": "Windows_Server-2022-English-Full-Base-*", "description": "Microsoft Windows Server 2022 Full Locale English AMI", "owner": "amazon" }, "windows2025": { "ami_name_filter": "Windows_Server-2025-English-Full-Base-*", "description": "Microsoft Windows Server 2025 Full Locale English AMI", "owner": "amazon" } }``` | no |
 | interface_vpc_endpoints | List of interface VPC endpoints to create | `list(string)` | ```[ "ec2", "ec2messages", "ecr.api", "ecr.dkr", "elasticloadbalancing", "logs", "monitoring", "ssm", "ssmmessages", "sts", "sqs" ]``` | no |
 | internal_subnets_cidr_blocks | CIDR blocks of internal subnets | `list(string)` | ```[ "10.0.128.0/24", "10.0.129.0/24", "10.0.130.0/24" ]``` | no |
 | private_subnets_cidr_blocks | CIDR blocks of private subnets | `list(string)` | ```[ "10.0.64.0/24", "10.0.65.0/24", "10.0.66.0/24" ]``` | no |

--- a/aws/arcgis-site-core/infrastructure-core/variables.tf
+++ b/aws/arcgis-site-core/infrastructure-core/variables.tf
@@ -63,7 +63,12 @@ variable "images" {
     ubuntu22 = {
       ami_name_filter = "ubuntu/images/hvm-ssd/ubuntu-*22*-amd64-server-*"
       owner           = "099720109477" # Canonical
-      description     = "Canonical, Ubuntu, 22.04 LTS, amd64 focal image"
+      description     = "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image"
+    }
+    ubuntu24 = {
+      ami_name_filter = "ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-amd64-server-*"
+      owner           = "099720109477" # Canonical
+      description     = "Canonical, Ubuntu, 24.04 LTS, amd64 noble image"
     }
     rhel9 = {
       ami_name_filter = "RHEL-9.5.0_HVM-*-x86_64-*-Hourly2-GP3"

--- a/config/aws/arcgis-site-core/automation-chef.tfvars.json
+++ b/config/aws/arcgis-site-core/automation-chef.tfvars.json
@@ -9,6 +9,10 @@
       "description": "Chef Client setup S3 key for Ubuntu 22.04 LTS",
       "path": "cinc/cinc_18.8.54-1.ubuntu22.amd64.deb"
     },
+    "ubuntu24": {
+      "description": "Chef Client setup S3 key for Ubuntu 24.04 LTS",
+      "path": "cinc/cinc_18.8.54-1.ubuntu24.amd64.deb"
+    },
     "windows2022": {
       "description": "Chef Client setup S3 key for Microsoft Windows Server 2022",
       "path": "cinc/cinc-18.8.54-1-x64.msi"

--- a/config/aws/arcgis-site-core/infrastructure-core.tfvars.json
+++ b/config/aws/arcgis-site-core/infrastructure-core.tfvars.json
@@ -21,8 +21,13 @@
     },
     "ubuntu22": {
       "ami_name_filter": "ubuntu/images/hvm-ssd/ubuntu-*22*-amd64-server-*",
-      "description": "Canonical, Ubuntu, 22.04 LTS, amd64 focal image",
+      "description": "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image",
       "owner": "099720109477"
+    },
+    "ubuntu24": {
+      "ami_name_filter": "ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-amd64-server-*",
+      "owner": "099720109477",
+      "description": "Canonical, Ubuntu, 24.04 LTS, amd64 noble image"
     },
     "windows2022": {
       "ami_name_filter": "Windows_Server-2022-English-Full-Base-*",


### PR DESCRIPTION
The following templates were modified to support Ubuntu 24.04:

- aws/arcgis-site-core
- aws/arcgis-enterprise-base-linux
- aws/arcgis-notebook-server-linux