### PR TITLE
#232 Added back *-iam-policies.sh scripts

### DIFF
--- a/aws/iam-policies/README.md
+++ b/aws/iam-policies/README.md
@@ -8,7 +8,7 @@ The directory contains user managed IAM policies for the GitHub Actions workflow
 
 ## Creating IAM Policies
 
-Use create-iam-policies.sh script create IAM policies for the GitHub Action workflows using the JSON policy documents.
+Use create-iam-policies.sh script to create IAM policies for the GitHub Action workflows using the JSON policy documents.
 
 Allow execution of the scripts in this directory:
 


### PR DESCRIPTION
This pull request updates the documentation for managing IAM policies used in GitHub Actions workflows. The main improvement is a shift from manual AWS CLI commands to using dedicated shell scripts for creating, updating, and deleting IAM policies, which streamlines and simplifies the workflow.

**Documentation and Workflow Improvements:**

* Replaced manual AWS CLI instructions with usage details for new shell scripts (`create-iam-policies.sh`, `update-iam-policies.sh`, and `delete-iam-policies.sh`) to automate IAM policy management.
* Added instructions for making the shell scripts executable and clarified how to run them.
* Provided guidance on updating and deleting IAM policies using the new scripts.

**General Clarifications:**

* Improved the introductory section to clarify the directory's purpose and the importance of correct ARN formats for different AWS regions.
* Updated the example command for attaching IAM policies to IAM users, making it more generic and easier to follow.