### PR TITLE
#263 Fix backup completion handling

### DIFF
--- a/enterprise-admin-cli/commands/create_backup.py
+++ b/enterprise-admin-cli/commands/create_backup.py
@@ -61,9 +61,10 @@ if __name__ == '__main__':
 
                 if job_status['status'] == 'COMPLETED':
                     print("Backup completed.")
-                    for stage in job_status['result']['stages']:
-                        print("Stage '{name}' {state} in {duration}.".format(
-                              name = stage['name'], state=stage['state'], duration = stage['duration']))
+                    if 'result' in job_status:
+                        for stage in job_status['result']['stages']:
+                            print("Stage '{name}' {state} in {duration}.".format(
+                                name = stage['name'], state=stage['state'], duration = stage['duration']))
                     break
                 elif job_status['status'] == 'FAILED':
                     raise RestServiceError(500, "Backup job failed.", job_status['messages'])


### PR DESCRIPTION
This pull request makes a minor improvement to the backup completion message by ensuring that stage details are only printed if the `result` field is present in the job status.

* Only print backup stage details if the `result` field exists in `job_status` to prevent potential errors when the field is missing. (`enterprise-admin-cli/commands/create_backup.py`)