### PR TITLE
#172 Updated keystore file path in application.tfvars.json

### DIFF
--- a/config/azure/arcgis-enterprise-base-windows/application.tfvars.json
+++ b/config/azure/arcgis-enterprise-base-windows/application.tfvars.json
@@ -18,7 +18,7 @@
   "deployment_id": "enterprise-base-windows",
   "is_upgrade": false,
   "keystore_file_password": "<keystore_file_password>",
-  "keystore_file_path": "~/config/certificates/<keystore_file_name>.pfx",
+  "keystore_file_path": "~/config/certificates/keystore.pfx",
   "log_level": "WARNING",
   "os": "windows2025",
   "portal_authorization_file_path": "~/config/authorization/12.0/portal_120.json",


### PR DESCRIPTION
This pull request makes a minor update to the `config/azure/arcgis-enterprise-base-windows/application.tfvars.json` configuration file. The change standardizes the keystore file path by replacing a placeholder with a specific file name.

* Updated the `keystore_file_path` value to use `keystore.pfx` instead of a placeholder, ensuring consistency and reducing ambiguity in the configuration.