### PR TITLE
#281 Update AWS templates

### DIFF
--- a/aws/arcgis-enterprise-base-linux/README.md
+++ b/aws/arcgis-enterprise-base-linux/README.md
@@ -56,8 +56,6 @@ Instructions:
 2. Commit the changes to a Git branch and push the branch to GitHub.
 3. Run enterprise-base-linux-aws-image workflow using the branch.
 
-> In the configuration files, "os" and "arcgis_version" properties values for the same deployment must match across all the configuration files of the deployment.
-
 ### 3. Provision AWS Resources
 
 GitHub Actions workflow **enterprise-base-linux-aws-infrastructure** creates AWS resources for base ArcGIS Enterprise deployment.

--- a/aws/arcgis-enterprise-base-linux/application/README.md
+++ b/aws/arcgis-enterprise-base-linux/application/README.md
@@ -54,11 +54,12 @@ The module reads the following SSM parameters:
 | /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | S3 bucket for the portal content |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
-| /arcgis/${var.site_id}/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
-| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
-| /arcgis/${var.site_id}/chef-client-url/${var.os} | Chef Client URL |
+| /arcgis/${var.site_id}/chef-client-url/${os} | Chef Client URL for the operating system |
 | /arcgis/${var.site_id}/cookbooks-url | Chef cookbooks URL |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the deployment |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
 | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -106,6 +107,7 @@ The module reads the following SSM parameters:
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_ssm_parameter.deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.object_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.os](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.portal_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.s3_content](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
@@ -131,7 +133,6 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (rhel9\|ubuntu22\|ubuntu24) | `string` | `"rhel9"` | no |
 | portal_authorization_file_path | Local path of Portal for ArcGIS authorization file | `string` | n/a | yes |
 | portal_user_license_type_id | Portal for ArcGIS administrator user license type Id | `string` | `""` | no |
 | root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS | `string` | `null` | no |

--- a/aws/arcgis-enterprise-base-linux/application/main.tf
+++ b/aws/arcgis-enterprise-base-linux/application/main.tf
@@ -54,11 +54,12 @@
  * | /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | S3 bucket for the portal content |
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
- * | /arcgis/${var.site_id}/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context | 
- * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context | 
- * | /arcgis/${var.site_id}/chef-client-url/${var.os} | Chef Client URL |
+ * | /arcgis/${var.site_id}/chef-client-url/${os} | Chef Client URL for the operating system |
  * | /arcgis/${var.site_id}/cookbooks-url | Chef cookbooks URL |
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the deployment |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context | 
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context | 
  * | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  * | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -116,12 +117,16 @@ data "aws_ssm_parameter" "deployment_fqdn" {
   name = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn"
 }
 
+data "aws_ssm_parameter" "os" {
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/os"
+}
+
 data "aws_ssm_parameter" "portal_web_context" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/portal-web-context"
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context"
 }
 
 data "aws_ssm_parameter" "server_web_context" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/server-web-context"
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context"
 }
 
 data "aws_ssm_parameter" "s3_content" {
@@ -190,6 +195,7 @@ locals {
 
   mount_point             = "/mnt/efs"
   deployment_fqdn         = nonsensitive(data.aws_ssm_parameter.deployment_fqdn.value)
+  os                      = nonsensitive(data.aws_ssm_parameter.os.value)
   portal_web_context      = nonsensitive(data.aws_ssm_parameter.portal_web_context.value)
   server_web_context      = nonsensitive(data.aws_ssm_parameter.server_web_context.value)
   primary_hostname        = "primary.${var.deployment_id}.${var.site_id}.internal"
@@ -283,7 +289,7 @@ module "s3_copy_files" {
 # Install Chef Client and Chef Cookbooks for ArcGIS on all EC2 instances of the deployment
 module "bootstrap_deployment" {
   source           = "../../modules/bootstrap"
-  os               = var.os
+  os               = local.os
   site_id          = var.site_id
   deployment_id    = var.deployment_id
   machine_roles    = ["primary", "standby"]

--- a/aws/arcgis-enterprise-base-linux/application/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/application/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +15,6 @@
 variable "aws_region" {
   description = "AWS region Id"
   type        = string
-}
-
-variable "os" {
-  description = "Operating system id (rhel9|ubuntu22|ubuntu24)"
-  type        = string
-  default     = "rhel9"
-
-  validation {
-    condition     = contains(["rhel9", "ubuntu22", "ubuntu24"], var.os)
-    error_message = "Valid values for os variable are rhel9, ubuntu22, and ubuntu24."
-  }
 }
 
 variable "site_id" {
@@ -76,6 +65,11 @@ variable "run_as_user" {
 variable "server_authorization_file_path" {
   description = "Local path of ArcGIS Server authorization file"
   type        = string
+
+  validation {
+    condition     = fileexists(var.server_authorization_file_path)
+    error_message = "The server_authorization_file_path value must be a valid file path."
+  }
 }
 
 variable "server_authorization_options" {
@@ -88,6 +82,11 @@ variable "server_authorization_options" {
 variable "portal_authorization_file_path" {
   description = "Local path of Portal for ArcGIS authorization file"
   type        = string
+
+  validation {
+    condition     = fileexists(var.portal_authorization_file_path)
+    error_message = "The portal_authorization_file_path value must be a valid file path."
+  }
 }
 
 variable "portal_user_license_type_id" {
@@ -100,6 +99,11 @@ variable "keystore_file_path" {
   description = "Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.keystore_file_path == null || try(fileexists(var.keystore_file_path), false)
+    error_message = "The keystore_file_path value must be a valid file path."
+  }
 }
 
 variable "keystore_file_password" {
@@ -113,6 +117,11 @@ variable "root_cert_file_path" {
   description = "Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.root_cert_file_path == null || try(fileexists(var.root_cert_file_path), false)
+    error_message = "The root_cert_file_path value must be a valid file path."
+  }  
 }
 
 variable "admin_username" {

--- a/aws/arcgis-enterprise-base-linux/backup/main.tf
+++ b/aws/arcgis-enterprise-base-linux/backup/main.tf
@@ -26,7 +26,7 @@
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-enterprise-base-linux/image/README.md
+++ b/aws/arcgis-enterprise-base-linux/image/README.md
@@ -26,9 +26,9 @@ On the machine where Packer is executed:
 
 * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
 * Path to aws/scripts directory must be added to PYTHONPATH
-* AWS credentials must be configured.
-
-My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+* AWS CLI must be installed and configured
+* AWS credentials must be configured
+* My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
 
 ## SSM Parameters
 
@@ -44,6 +44,16 @@ The template uses the following SSM parameters:
 | /arcgis/${var.site_id}/s3/region | S3 buckets region code |
 | /arcgis/${var.site_id}/s3/repository | Private repository S3 bucket |
 | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
+
+The template writes the following SSM parameters:
+
+| SSM parameter name | Description |
+|--------------------|-------------|
+| /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI ID for the deployment |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby AMI ID for the deployment |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the AMI |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 
 ## Inputs
 

--- a/aws/arcgis-enterprise-base-linux/image/main.pkr.hcl
+++ b/aws/arcgis-enterprise-base-linux/image/main.pkr.hcl
@@ -31,8 +31,9 @@
  * 
  * * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
  * * Path to aws/scripts directory must be added to PYTHONPATH
+ * * AWS CLI must be installed and configured
  * * AWS credentials must be configured.
- * * My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+ * * My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
  * 
  * ## SSM Parameters
  * 
@@ -48,9 +49,19 @@
  * | /arcgis/${var.site_id}/s3/region | S3 buckets region code |
  * | /arcgis/${var.site_id}/s3/repository | Private repository S3 bucket |
  * | /arcgis/${var.site_id}/vpc/subnets | IDs of VPC subnets |
+ *
+ * The template writes the following SSM parameters:
+ *
+ * | SSM parameter name | Description |
+ * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI ID for the deployment |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby AMI ID for the deployment |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the AMI |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -391,5 +402,18 @@ build {
     }
 
     command = "python -m publish_artifact -p /arcgis/${var.site_id}/images/${var.deployment_id}/standby -f packer-manifest.json -r ${build.PackerRunUUID}"
+  }
+
+  # Save os, portal_web_context and server_web_context in SSM parameters for later use in deployment.
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/os --value ${var.os} --type String --region ${var.aws_region}"
+  }
+
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context --value ${var.portal_web_context} --type String --region ${var.aws_region}"
+  }
+
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context --value ${var.server_web_context} --type String --region ${var.aws_region}"
   }
 }

--- a/aws/arcgis-enterprise-base-linux/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/README.md
@@ -51,13 +51,15 @@ The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
+| /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | Security group ID of the application load balancer |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the site ingress |
-| /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer |
 | /arcgis/${var.site_id}/backup/vault-name | Name of the AWS Backup vault |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby EC2 instance AMI ID |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM commands output |
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone ID |
@@ -73,15 +75,13 @@ The module writes the following SSM parameters:
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-url | Portal for ArcGIS URL of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | Object store S3 bucket |
-| /arcgis/${var.site_id}/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
 | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group ID |
-| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 6.10 |
+| aws | ~> 6.37 |
 
 ## Modules
 
@@ -121,9 +121,7 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.deployment_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.object_store_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.portal_content_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.portal_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ami.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_ssm_parameter.alb_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
@@ -131,7 +129,9 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.alb_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.backup_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.backup_vault_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.portal_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.primary_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.standby_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
@@ -146,11 +146,9 @@ The module writes the following SSM parameters:
 | instance_type | EC2 instance type | `string` | `"m7i.2xlarge"` | no |
 | is_ha | If true, the deployment is in high availability mode | `bool` | `true` | no |
 | key_name | EC2 key pair name | `string` | n/a | yes |
-| portal_web_context | Portal for ArcGIS web context | `string` | `"portal"` | no |
 | root_volume_iops | Root EBS volume IOPS of primary and standby EC2 instances | `number` | `3000` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `1024` | no |
 | root_volume_throughput | Root EBS volume throughput in MB/s of primary and standby EC2 instances | `number` | `125` | no |
-| server_web_context | ArcGIS Server web context | `string` | `"server"` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis"` | no |
 | subnet_ids | EC2 instances subnet IDs (by default, the first two private VPC subnets are used) | `list(string)` | `[]` | no |
 

--- a/aws/arcgis-enterprise-base-linux/infrastructure/ingress.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/ingress.tf
@@ -20,6 +20,19 @@ data "aws_ssm_parameter" "alb_arn" {
   name  = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn"
 }
 
+data "aws_ssm_parameter" "portal_web_context" {
+  name  = "/arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context"
+}
+
+data "aws_ssm_parameter" "server_web_context" {
+  name  = "/arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context"
+}
+
+locals {
+  portal_web_context = nonsensitive(data.aws_ssm_parameter.portal_web_context.value)
+  server_web_context = nonsensitive(data.aws_ssm_parameter.server_web_context.value)
+}
+
 # Create Application Load Balancer target group for HTTPS port 443, attach 
 # primary and standby instances to it, and add the target group to the load balancer. 
 # Configure the target group to forward requests to /portal and /server HTTP contexts.
@@ -31,8 +44,8 @@ module "server_https_alb_target" {
   protocol          = "HTTPS"
   alb_port          = 443
   instance_port     = 443
-  health_check_path = "/${var.server_web_context}/rest/info/healthcheck"
-  path_patterns     = ["/${var.server_web_context}", "/${var.server_web_context}/*"]
+  health_check_path = "/${local.server_web_context}/rest/info/healthcheck"
+  web_context       = local.server_web_context
   priority          = 100
   target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.standby : n.id])
 }
@@ -48,8 +61,8 @@ module "portal_https_alb_target" {
   protocol          = "HTTPS"
   alb_port          = 443
   instance_port     = 443
-  health_check_path = "/${var.portal_web_context}/portaladmin/healthCheck"
-  path_patterns     = ["/${var.portal_web_context}", "/${var.portal_web_context}/*"]
+  health_check_path = "/${local.portal_web_context}/portaladmin/healthCheck"
+  web_context       = local.portal_web_context
   priority          = 101
   target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.standby : n.id])
 }
@@ -61,23 +74,9 @@ resource "aws_ssm_parameter" "deployment_fqdn" {
   description = "Fully qualified domain name of the deployment"
 }
 
-resource "aws_ssm_parameter" "portal_web_context" {
-  name        = "/arcgis/${var.site_id}/${var.deployment_id}/portal-web-context"
-  type        = "String"
-  value       = var.portal_web_context
-  description = "Portal for ArcGIS web context"
-}
-
-resource "aws_ssm_parameter" "server_web_context" {
-  name        = "/arcgis/${var.site_id}/${var.deployment_id}/server-web-context"
-  type        = "String"
-  value       = var.server_web_context
-  description = "ArcGIS Server web context"
-}
-
 resource "aws_ssm_parameter" "deployment_url" {
   name        = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-url"
   type        = "String"
-  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${var.portal_web_context}"
+  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${local.portal_web_context}"
   description = "Portal for ArcGIS URL of the deployment"
 }

--- a/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/main.tf
@@ -51,13 +51,15 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | Security group ID of the application load balancer |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the site ingress |
- * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer |
  * | /arcgis/${var.site_id}/backup/vault-name | Name of the AWS Backup vault |
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby EC2 instance AMI ID |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM commands output |
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone ID |
@@ -73,9 +75,7 @@
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-url | Portal for ArcGIS URL of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | Object store S3 bucket |
- * | /arcgis/${var.site_id}/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
  * | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group ID |
- * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  */
 
 # Copyright 2024-2026 Esri
@@ -100,7 +100,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.10"
+      version = "~> 6.37"
     }
   }
 

--- a/aws/arcgis-enterprise-base-linux/infrastructure/outputs.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/outputs.tf
@@ -19,5 +19,5 @@ output "security_group_id" {
 
 output "deployment_url" {
   description = "Portal for ArcGIS URL of the deployment"
-  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${var.portal_web_context}"
+  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${local.portal_web_context}"
 }

--- a/aws/arcgis-enterprise-base-linux/infrastructure/variables.tf
+++ b/aws/arcgis-enterprise-base-linux/infrastructure/variables.tf
@@ -68,12 +68,6 @@ variable "key_name" {
   type        = string
 }
 
-variable "portal_web_context" {
-  description = "Portal for ArcGIS web context"
-  type        = string
-  default     = "portal"  
-}
-
 variable "root_volume_iops" {
   description = "Root EBS volume IOPS of primary and standby EC2 instances"
   type        = number
@@ -105,12 +99,6 @@ variable "root_volume_throughput" {
     condition     = var.root_volume_throughput >= 125 && var.root_volume_throughput <= 1000
     error_message = "The root_volume_throughput value must be between 125 and 1000."
   }
-}
-
-variable "server_web_context" {
-  description = "ArcGIS Server web context"
-  type        = string
-  default     = "server"  
 }
 
 variable "site_id" {

--- a/aws/arcgis-enterprise-base-linux/restore/main.tf
+++ b/aws/arcgis-enterprise-base-linux/restore/main.tf
@@ -27,7 +27,7 @@
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-application.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-application.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Output
       id: output  
       run: echo arcgis_portal_url=$(terraform output arcgis_portal_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-backup.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-backup.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,8 +66,8 @@ jobs:
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/backup.tfstate" -backend-config="region=$TF_VAR_aws_region"
         if [ ${{ github.event.inputs.backup_restore_mode }} != "" ]; then
-          terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
+          terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve -input=false
         else 
-          terraform apply -var-file $CONFIG_FILE -auto-approve
+          terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
         fi
         

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-destroy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Link Config Directory
+        run: ln -s ${{ github.workspace }}/config ~/config
       - name: Install boto3
         id: install-boto3
         run: pip install boto3
@@ -58,7 +60,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve -input=false
       - name: Destroy Infrastructure
         id: infrastructure-destroy
         working-directory: aws/arcgis-enterprise-base-linux/infrastructure
@@ -66,7 +68,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
       - name: Delete AMIs
         id: delete-amis
         run: |

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-infrastructure.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-infrastructure.yaml
@@ -65,11 +65,11 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: github.event.inputs.terraform_command != 'plan'
-      run: terraform apply -var-file $CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: github.event.inputs.terraform_command == 'plan'
-      run: terraform plan -var-file $CONFIG_FILE 
+      run: terraform plan -var-file $CONFIG_FILE -input=false
     - name: Terraform Output
       id: output  
       run: echo deployment_url=$(terraform output deployment_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-recover.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-recover.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Esri
+# Copyright 2025-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: ${{ inputs.test_mode == false }}
-      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: ${{ inputs.test_mode == true }}

--- a/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-restore.yaml
+++ b/aws/arcgis-enterprise-base-linux/workflows/enterprise-base-linux-aws-restore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,5 +63,5 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/restore.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
+        terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve -input=false
 

--- a/aws/arcgis-enterprise-base-windows/README.md
+++ b/aws/arcgis-enterprise-base-windows/README.md
@@ -58,8 +58,6 @@ Instructions:
 2. Commit the changes to a Git branch and push the branch to GitHub.
 3. Run the enterprise-base-windows-aws-image workflow using the branch.
 
-> In the configuration files, "os" and "arcgis_version" property values for the same deployment must match across all the configuration files of the deployment.
-
 ### 3. Provision AWS Resources
 
 GitHub Actions workflow **enterprise-base-windows-aws-infrastructure** creates AWS resources for base ArcGIS Enterprise deployment.

--- a/aws/arcgis-enterprise-base-windows/application/README.md
+++ b/aws/arcgis-enterprise-base-windows/application/README.md
@@ -54,11 +54,12 @@ The module reads the following SSM parameters:
 | /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | S3 bucket for the portal content |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
-| /arcgis/${var.site_id}/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
-| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |  
-| /arcgis/${var.site_id}/chef-client-url/${var.os} | Chef Client URL |
+| /arcgis/${var.site_id}/chef-client-url/${os} | Chef Client URL for the operating system |
 | /arcgis/${var.site_id}/cookbooks-url | Chef cookbooks URL |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system id |   
+| /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |  
 | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
 | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -104,6 +105,7 @@ The module reads the following SSM parameters:
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_ssm_parameter.deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.object_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.os](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.portal_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.s3_content](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
@@ -129,7 +131,6 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (windows2022\|windows2025) | `string` | `"windows2025"` | no |
 | portal_authorization_file_path | Local path of Portal for ArcGIS authorization file | `string` | n/a | yes |
 | portal_user_license_type_id | Portal for ArcGIS administrator user license type Id | `string` | `""` | no |
 | root_cert_file_path | Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS | `string` | `null` | no |

--- a/aws/arcgis-enterprise-base-windows/application/main.tf
+++ b/aws/arcgis-enterprise-base-windows/application/main.tf
@@ -54,11 +54,12 @@
  * | /arcgis/${var.site_id}/${var.deployment_id}/content-s3-bucket | S3 bucket for the portal content |
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
- * | /arcgis/${var.site_id}/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context | 
- * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |  
- * | /arcgis/${var.site_id}/chef-client-url/${var.os} | Chef Client URL |
+ * | /arcgis/${var.site_id}/chef-client-url/${os} | Chef Client URL for the operating system |
  * | /arcgis/${var.site_id}/cookbooks-url | Chef cookbooks URL |
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system id |   
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context | 
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |  
  * | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output | 
  * | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -77,7 +78,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
+
 terraform {
   backend "s3" {
     key = "terraform/arcgis/enterprise-base-windows/application.tfstate"
@@ -95,10 +96,10 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  
+
   default_tags {
     tags = {
-      ArcGISAutomation   = "arcgis-gitops"      
+      ArcGISAutomation   = "arcgis-gitops"
       ArcGISSiteId       = var.site_id
       ArcGISDeploymentId = var.deployment_id
     }
@@ -109,16 +110,20 @@ provider "aws" {
   }
 }
 
-data "aws_ssm_parameter" "deployment_fqdn" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn"
+data "aws_ssm_parameter" "os" {
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/os"
 }
 
 data "aws_ssm_parameter" "portal_web_context" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/portal-web-context"
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context"
 }
 
 data "aws_ssm_parameter" "server_web_context" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/server-web-context"
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context"
+}
+
+data "aws_ssm_parameter" "deployment_fqdn" {
+  name = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn"
 }
 
 data "aws_ssm_parameter" "s3_content" {
@@ -206,11 +211,12 @@ locals {
   authorization_files_s3_prefix = "software/authorization/${var.arcgis_version}"
   certificates_s3_prefix        = "software/certificates"
 
-  deployment_fqdn     = nonsensitive(data.aws_ssm_parameter.deployment_fqdn.value)
-  portal_web_context  = nonsensitive(data.aws_ssm_parameter.portal_web_context.value)
-  server_web_context  = nonsensitive(data.aws_ssm_parameter.server_web_context.value)
-  primary_hostname    = "primary.${var.deployment_id}.${var.site_id}.internal"
-  standby_hostname    = "standby.${var.deployment_id}.${var.site_id}.internal"
+  deployment_fqdn    = nonsensitive(data.aws_ssm_parameter.deployment_fqdn.value)
+  os                 = nonsensitive(data.aws_ssm_parameter.os.value)
+  portal_web_context = nonsensitive(data.aws_ssm_parameter.portal_web_context.value)
+  server_web_context = nonsensitive(data.aws_ssm_parameter.server_web_context.value)
+  primary_hostname   = "primary.${var.deployment_id}.${var.site_id}.internal"
+  standby_hostname   = "standby.${var.deployment_id}.${var.site_id}.internal"
 
   software_dir            = "C:\\Software\\*"
   authorization_files_dir = "C:\\Software\\AuthorizationFiles"
@@ -238,14 +244,14 @@ locals {
           regionEndpointUrl = "https://s3.${data.aws_region.current.id}.amazonaws.com"
           rootDir           = "arcgis"
         }
-      }, {
+        }, {
         type     = "tableStore"
         name     = "Amazon Dynamo DB"
         category = "storage"
         connection = {
           regionEndpointUrl = "https://dynamodb.${data.aws_region.current.id}.amazonaws.com"
         }
-      }, {
+        }, {
         type     = "queueService"
         name     = "Amazon Queue Service"
         category = "queue"
@@ -255,9 +261,9 @@ locals {
       }]
       cloudServiceTags = [{
         ArcGISSiteId = var.site_id
-      }, {
+        }, {
         ArcGISDeploymentId = var.deployment_id
-      }, {
+        }, {
         ArcGISRole = "config-store"
       }]
     }]
@@ -286,24 +292,24 @@ locals {
 }
 
 module "site_core_info" {
-  source         = "../../modules/site_core_info"
-  site_id        = var.site_id
+  source  = "../../modules/site_core_info"
+  site_id = var.site_id
 }
 
 module "s3_copy_files" {
-  count                  = var.is_upgrade ? 1 : 0
-  source                 = "../../modules/s3_copy_files"
-  bucket_name            = module.site_core_info.s3_repository
-  index_file             = local.manifest_file_path
+  count       = var.is_upgrade ? 1 : 0
+  source      = "../../modules/s3_copy_files"
+  bucket_name = module.site_core_info.s3_repository
+  index_file  = local.manifest_file_path
 }
 
 # Install Chef Client and Chef Cookbooks for ArcGIS on all EC2 instances of the deployment
 module "bootstrap_deployment" {
-  source        = "../../modules/bootstrap"
-  site_id       = var.site_id
-  deployment_id = var.deployment_id
-  machine_roles = ["primary", "standby"]
-  os           = var.os
+  source           = "../../modules/bootstrap"
+  site_id          = var.site_id
+  deployment_id    = var.deployment_id
+  machine_roles    = ["primary", "standby"]
+  os               = local.os
   output_s3_bucket = module.site_core_info.s3_logs
 }
 
@@ -338,8 +344,8 @@ module "begin_upgrade_standby" {
   machine_roles  = ["standby"]
   json_attributes = jsonencode({
     arcgis = {
-      version = var.arcgis_version
-      configure_cloud_settings   = false
+      version                  = var.arcgis_version
+      configure_cloud_settings = false
       server = {
         admin_username = var.admin_username
         admin_password = var.admin_password
@@ -586,7 +592,7 @@ module "keystore_file" {
   machine_roles  = ["primary", "standby"]
   json_attributes = jsonencode({
     arcgis = {
-      version = var.arcgis_version
+      version                  = var.arcgis_version
       configure_cloud_settings = false
       repository = {
         local_archives = local.certificates_dir
@@ -667,7 +673,7 @@ module "arcgis_enterprise_primary" {
       # without activating the deployment (routing deployment_fqdn to the deployment's ALB).
       hosts = {
         "${local.primary_hostname} FILESERVER" = ""
-      }      
+      }
       repository = {
         archives = local.archives_dir
         setups   = "C:\\Software\\Setups"
@@ -679,25 +685,25 @@ module "arcgis_enterprise_primary" {
         replace_https_binding = true
       }
       server = {
-        url                            = "https://${local.primary_hostname}:6443/arcgis"
-        wa_url                         = "https://${local.primary_hostname}/${local.server_web_context}"
-        install_dir                    = "C:\\Program Files\\ArcGIS\\Server"
-        install_system_requirements    = true
-        private_url                    = "https://${local.deployment_fqdn}/${local.server_web_context}"
-        web_context_url                = "https://${local.deployment_fqdn}/${local.server_web_context}"
-        hostname                       = local.primary_hostname
-        admin_username                 = var.admin_username
-        admin_password                 = var.admin_password
-        authorization_file             = "${local.authorization_files_dir}\\${basename(var.server_authorization_file_path)}"
-        authorization_options          = var.server_authorization_options
-        keystore_file                  = var.keystore_file_path != null ? local.keystore_file : ""
-        keystore_password              = var.keystore_file_password
-        root_cert                      = local.root_cert
-        root_cert_alias                = "rootcert"
-        directories_root               = "\\\\FILESERVER\\arcgisserver"
-        log_dir                        = "C:\\arcgisserver\\logs"
-        log_level                      = var.log_level
-        config_store_type              = var.config_store_type
+        url                         = "https://${local.primary_hostname}:6443/arcgis"
+        wa_url                      = "https://${local.primary_hostname}/${local.server_web_context}"
+        install_dir                 = "C:\\Program Files\\ArcGIS\\Server"
+        install_system_requirements = true
+        private_url                 = "https://${local.deployment_fqdn}/${local.server_web_context}"
+        web_context_url             = "https://${local.deployment_fqdn}/${local.server_web_context}"
+        hostname                    = local.primary_hostname
+        admin_username              = var.admin_username
+        admin_password              = var.admin_password
+        authorization_file          = "${local.authorization_files_dir}\\${basename(var.server_authorization_file_path)}"
+        authorization_options       = var.server_authorization_options
+        keystore_file               = var.keystore_file_path != null ? local.keystore_file : ""
+        keystore_password           = var.keystore_file_password
+        root_cert                   = local.root_cert
+        root_cert_alias             = "rootcert"
+        directories_root            = "\\\\FILESERVER\\arcgisserver"
+        log_dir                     = "C:\\arcgisserver\\logs"
+        log_level                   = var.log_level
+        config_store_type           = var.config_store_type
         # If cloud_config is set, config_store_connection_string is ignored
         config_store_connection_string = "\\\\FILESERVER\\arcgisserver\\config-store"
         cloud_config                   = local.cloud_config
@@ -784,7 +790,7 @@ module "arcgis_enterprise_primary" {
       "recipe[arcgis-enterprise::server]",
       "recipe[arcgis-enterprise::server_wa]",
       "recipe[arcgis-enterprise::datastore]",
-      "recipe[arcgis-enterprise::server_data_items]",      
+      "recipe[arcgis-enterprise::server_data_items]",
       "recipe[arcgis-enterprise::federation]"
     ]
   })
@@ -814,7 +820,7 @@ module "arcgis_enterprise_standby" {
       hosts = {
         "${local.standby_hostname}" = ""
         "FILESERVER"                = "${data.aws_instance.primary.private_ip}"
-      }      
+      }
       repository = {
         archives = local.archives_dir
         setups   = "C:\\Software\\Setups"
@@ -916,11 +922,11 @@ module "backup" {
 # Delete the downloaded setup archives, the extracted setups, and other 
 # temporary files from primary and standby EC2 instances.
 module "clean_up" {
-  source        = "../../modules/clean_up"
-  site_id       = var.site_id
-  deployment_id = var.deployment_id
-  machine_roles = ["primary", "standby"]
-  directories   = [local.software_dir]
+  source                = "../../modules/clean_up"
+  site_id               = var.site_id
+  deployment_id         = var.deployment_id
+  machine_roles         = ["primary", "standby"]
+  directories           = [local.software_dir]
   uninstall_chef_client = false
   depends_on = [
     module.arcgis_enterprise_primary,

--- a/aws/arcgis-enterprise-base-windows/application/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/application/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +15,6 @@
 variable "aws_region" {
   description = "AWS region Id"
   type        = string
-}
-
-variable "os" {
-  description = "Operating system id (windows2022|windows2025)"
-  type        = string
-  default     = "windows2025"
-
-  validation {
-    condition     = contains(["windows2022", "windows2025"], var.os)
-    error_message = "Valid values for os variable are windows2022 and windows2025."
-  }
 }
 
 variable "site_id" {
@@ -82,6 +71,11 @@ variable "run_as_password" {
 variable "server_authorization_file_path" {
   description = "Local path of ArcGIS Server authorization file"
   type        = string
+
+  validation {
+    condition     = fileexists(var.server_authorization_file_path)
+    error_message = "The server_authorization_file_path value must be a valid file path."
+  }
 }
 
 variable "server_authorization_options" {
@@ -94,6 +88,11 @@ variable "server_authorization_options" {
 variable "portal_authorization_file_path" {
   description = "Local path of Portal for ArcGIS authorization file"
   type        = string
+
+  validation {
+    condition     = fileexists(var.portal_authorization_file_path)
+    error_message = "The portal_authorization_file_path value must be a valid file path."
+  }
 }
 
 variable "portal_user_license_type_id" {
@@ -106,6 +105,11 @@ variable "keystore_file_path" {
   description = "Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.keystore_file_path == null || try(fileexists(var.keystore_file_path), false)
+    error_message = "The keystore_file_path value must be a valid file path."
+  }
 }
 
 variable "keystore_file_password" {
@@ -119,6 +123,11 @@ variable "root_cert_file_path" {
   description = "Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.root_cert_file_path == null || try(fileexists(var.root_cert_file_path), false)
+    error_message = "The root_cert_file_path value must be a valid file path."
+  }    
 }
 
 variable "admin_username" {

--- a/aws/arcgis-enterprise-base-windows/backup/main.tf
+++ b/aws/arcgis-enterprise-base-windows/backup/main.tf
@@ -25,7 +25,7 @@
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-enterprise-base-windows/image/README.md
+++ b/aws/arcgis-enterprise-base-windows/image/README.md
@@ -24,8 +24,9 @@ On the machine where Packer is executed:
 
 * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
 * Path to aws/scripts directory must be added to PYTHONPATH
-* AWS credentials must be configured.
-* My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+* AWS CLI must be installed and configured
+* AWS credentials must be configured
+* My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
 
 ## SSM Parameters
 
@@ -41,6 +42,16 @@ The template uses the following SSM parameters:
 | /arcgis/${var.site_id}/s3/region | S3 buckets region code |
 | /arcgis/${var.site_id}/s3/repository | Private repository S3 bucket |
 | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
+
+The template writes the following SSM parameters:
+
+| SSM parameter name | Description |
+|--------------------|-------------|
+| /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI ID for the deployment |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby AMI ID for the deployment |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the AMI |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 
 ## Inputs
 

--- a/aws/arcgis-enterprise-base-windows/image/main.pkr.hcl
+++ b/aws/arcgis-enterprise-base-windows/image/main.pkr.hcl
@@ -29,8 +29,9 @@
  * 
  * * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
  * * Path to aws/scripts directory must be added to PYTHONPATH
- * * AWS credentials must be configured.
- * * My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+ * * AWS CLI must be installed and configured 
+ * * AWS credentials must be configured
+ * * My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
  * 
  * ## SSM Parameters
  * 
@@ -46,9 +47,19 @@
  * | /arcgis/${var.site_id}/s3/region | S3 buckets region code |
  * | /arcgis/${var.site_id}/s3/repository | Private repository S3 bucket |
  * | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
+ *
+ * The template writes the following SSM parameters:
+ *
+ * | SSM parameter name | Description |
+ * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI ID for the deployment |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby AMI ID for the deployment |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the AMI |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -347,6 +358,19 @@ build {
     }
 
     command = "python -m publish_artifact -p /arcgis/${var.site_id}/images/${var.deployment_id}/standby -f main-packer-manifest.json -r ${build.PackerRunUUID}"
+  }
+
+  # Save os, portal_web_context and server_web_context in SSM parameters for later use in deployment.
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/os --value ${var.os} --type String --region ${var.aws_region}"
+  }
+
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context --value ${var.portal_web_context} --type String --region ${var.aws_region}"
+  }
+
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context --value ${var.server_web_context} --type String --region ${var.aws_region}"
   }
 }
 

--- a/aws/arcgis-enterprise-base-windows/infrastructure/README.md
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/README.md
@@ -45,13 +45,15 @@ The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
+| /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | Security group ID of the application load balancer |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the site ingress |
-| /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer |
 | /arcgis/${var.site_id}/backup/vault-name | Name of the AWS Backup vault |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby EC2 instance AMI ID |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM commands output |
 | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone ID |
@@ -111,16 +113,16 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.deployment_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.object_store_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.portal_content_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.portal_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ami.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ssm_parameter.alb_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.alb_deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.alb_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.backup_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.backup_vault_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.portal_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.primary_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.standby_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
@@ -135,11 +137,9 @@ The module writes the following SSM parameters:
 | instance_type | EC2 instance type | `string` | `"m7i.2xlarge"` | no |
 | is_ha | If true, the deployment is in high availability mode | `bool` | `true` | no |
 | key_name | EC2 key pair name | `string` | n/a | yes |
-| portal_web_context | Portal for ArcGIS web context | `string` | `"portal"` | no |
 | root_volume_iops | Root EBS volume IOPS of primary and standby EC2 instances | `number` | `3000` | no |
 | root_volume_size | Root EBS volume size in GB of primary and standby EC2 instances | `number` | `1024` | no |
 | root_volume_throughput | Root EBS volume throughput in MB/s of primary and standby EC2 instances | `number` | `125` | no |
-| server_web_context | ArcGIS Server web context | `string` | `"server"` | no |
 | site_id | ArcGIS site Id | `string` | `"arcgis"` | no |
 | subnet_ids | EC2 instances subnet IDs (by default, the first two private VPC subnets are used) | `list(string)` | `[]` | no |
 

--- a/aws/arcgis-enterprise-base-windows/infrastructure/ingress.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/ingress.tf
@@ -19,7 +19,20 @@ data "aws_ssm_parameter" "alb_deployment_fqdn" {
 data "aws_ssm_parameter" "alb_arn" {
   name  = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn"
 }
-  
+
+data "aws_ssm_parameter" "portal_web_context" {
+  name  = "/arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context"
+}
+
+data "aws_ssm_parameter" "server_web_context" {
+  name  = "/arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context"
+}
+
+locals {
+  portal_web_context = nonsensitive(data.aws_ssm_parameter.portal_web_context.value)
+  server_web_context = nonsensitive(data.aws_ssm_parameter.server_web_context.value)
+}
+
 # Create Application Load Balancer target group for HTTPS port 443, attach 
 # primary and standby instances to it, and add the target group to the load balancer. 
 # Configure the target group to forward requests to /portal and /server HTTP contexts.
@@ -31,8 +44,8 @@ module "server_https_alb_target" {
   protocol          = "HTTPS"
   alb_port          = 443
   instance_port     = 443
-  health_check_path = "/${var.server_web_context}/rest/info/healthcheck"
-  path_patterns     = ["/${var.server_web_context}", "/${var.server_web_context}/*"]
+  health_check_path = "/${local.server_web_context}/rest/info/healthcheck"
+  web_context       = local.server_web_context
   priority          = 100
   target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.standby : n.id])
 }
@@ -48,24 +61,10 @@ module "portal_https_alb_target" {
   protocol          = "HTTPS"
   alb_port          = 443
   instance_port     = 443
-  health_check_path = "/${var.portal_web_context}/portaladmin/healthCheck"
-  path_patterns     = ["/${var.portal_web_context}", "/${var.portal_web_context}/*"]
+  health_check_path = "/${local.portal_web_context}/portaladmin/healthCheck"
+  web_context       = local.portal_web_context
   priority          = 101
   target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.standby : n.id])
-}
-
-resource "aws_ssm_parameter" "portal_web_context" {
-  name        = "/arcgis/${var.site_id}/${var.deployment_id}/portal-web-context"
-  type        = "String"
-  value       = var.portal_web_context
-  description = "Portal for ArcGIS web context"
-}
-
-resource "aws_ssm_parameter" "server_web_context" {
-  name        = "/arcgis/${var.site_id}/${var.deployment_id}/server-web-context"
-  type        = "String"
-  value       = var.server_web_context
-  description = "ArcGIS Server web context"
 }
 
 resource "aws_ssm_parameter" "deployment_fqdn" {
@@ -78,6 +77,6 @@ resource "aws_ssm_parameter" "deployment_fqdn" {
 resource "aws_ssm_parameter" "deployment_url" {
   name        = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-url"
   type        = "String"
-  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${var.portal_web_context}"
+  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${local.portal_web_context}"
   description = "Portal for ArcGIS URL of the deployment"
 }

--- a/aws/arcgis-enterprise-base-windows/infrastructure/main.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/main.tf
@@ -45,13 +45,15 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer | 
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | Security group ID of the application load balancer |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the site ingress |
- * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ARN of the application load balancer | 
  * | /arcgis/${var.site_id}/backup/vault-name | Name of the AWS Backup vault |
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/portal-web-context | Portal for ArcGIS web context |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/standby | Standby EC2 instance AMI ID |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM commands output |
  * | /arcgis/${var.site_id}/vpc/hosted-zone-id | VPC hosted zone ID |

--- a/aws/arcgis-enterprise-base-windows/infrastructure/outputs.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/outputs.tf
@@ -19,5 +19,5 @@ output "security_group_id" {
 
 output "deployment_url" {
   description = "Portal for ArcGIS URL of the deployment"
-  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${var.portal_web_context}"
+  value       = "https://${nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)}/${local.portal_web_context}"
 }

--- a/aws/arcgis-enterprise-base-windows/infrastructure/variables.tf
+++ b/aws/arcgis-enterprise-base-windows/infrastructure/variables.tf
@@ -68,12 +68,6 @@ variable "key_name" {
   type        = string
 }
 
-variable "portal_web_context" {
-  description = "Portal for ArcGIS web context"
-  type        = string
-  default     = "portal"
-}
-
 variable "root_volume_iops" {
   description = "Root EBS volume IOPS of primary and standby EC2 instances"
   type        = number
@@ -105,12 +99,6 @@ variable "root_volume_throughput" {
     condition     = var.root_volume_throughput >= 125 && var.root_volume_throughput <= 1000
     error_message = "The root_volume_throughput value must be between 125 and 1000."
   }
-}
-
-variable "server_web_context" {
-  description = "ArcGIS Server web context"
-  type        = string
-  default     = "server"
 }
 
 variable "site_id" {

--- a/aws/arcgis-enterprise-base-windows/restore/main.tf
+++ b/aws/arcgis-enterprise-base-windows/restore/main.tf
@@ -27,7 +27,7 @@
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-application.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-application.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Output
       id: output  
       run: echo arcgis_portal_url=$(terraform output arcgis_portal_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-backup.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-backup.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ jobs:
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/backup.tfstate" -backend-config="region=$TF_VAR_aws_region"
         if [ ${{ github.event.inputs.backup_restore_mode }} != "" ]; then
-          terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
+          terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve -input=false
         else 
-          terraform apply -var-file $CONFIG_FILE -auto-approve
+          terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
         fi

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-destroy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Link Config Directory
+      run: ln -s ${{ github.workspace }}/config ~/config
     - name: Install Boto3
       id: install-boto3
       run: pip install boto3
@@ -59,7 +61,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
+        terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve -input=false
     - name: Destroy Infrastructure
       id: infrastructure-destroy
       working-directory: aws/arcgis-enterprise-base-windows/infrastructure
@@ -67,7 +69,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-        terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+        terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
     - name: Delete AMIs
       id: delete-amis
       run: |

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-infrastructure.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-infrastructure.yaml
@@ -65,11 +65,11 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: github.event.inputs.terraform_command != 'plan'
-      run: terraform apply -var-file $CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: github.event.inputs.terraform_command == 'plan'
-      run: terraform plan -var-file $CONFIG_FILE 
+      run: terraform plan -var-file $CONFIG_FILE -input=false 
     - name: Terraform Output
       id: output  
       run: echo deployment_url=$(terraform output deployment_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-recover.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-recover.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Esri
+# Copyright 2025-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: ${{ inputs.test_mode == false }}
-      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: ${{ inputs.test_mode == true }}

--- a/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-restore.yaml
+++ b/aws/arcgis-enterprise-base-windows/workflows/enterprise-base-windows-aws-restore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,4 +64,4 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/restore.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve
+        terraform apply -var-file $CONFIG_FILE -var "backup_restore_mode=${{ github.event.inputs.backup_restore_mode }}" -auto-approve -input=false

--- a/aws/arcgis-enterprise-k8s/organization/variables.tf
+++ b/aws/arcgis-enterprise-k8s/organization/variables.tf
@@ -89,6 +89,11 @@ variable "arcgis_version" {
 variable "authorization_file_path" {
   description = "ArcGIS Enterprise on Kubernetes authorization file path"
   type        = string
+
+  validation {
+    condition     = fileexists(var.authorization_file_path)
+    error_message = "The authorization_file_path value must be a valid file path."
+  }  
 }
 
 variable "aws_region" {

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-destroy.yaml
@@ -71,7 +71,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $ORGANIZATION_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $ORGANIZATION_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/organization.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform destroy -var-file $ORGANIZATION_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $ORGANIZATION_CONFIG_FILE -auto-approve -input=false
       - name: Destroy Ingress
         id: destroy-ingress
         if: ${{ inputs.delete_namespace != false }}
@@ -80,6 +80,6 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $INGRESS_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $INGRESS_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/ingress.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform destroy -var-file $INGRESS_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $INGRESS_CONFIG_FILE -auto-approve -input=false
 
 

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-ingress.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/ingress.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform apply -var-file $CONFIG_FILE -auto-approve 
+          terraform apply -var-file $CONFIG_FILE -auto-approve -input=false 
       - name: Terraform Output
         id: output  
         run: |

--- a/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-organization.yaml
+++ b/aws/arcgis-enterprise-k8s/workflows/enterprise-k8s-aws-organization.yaml
@@ -70,7 +70,7 @@ jobs:
           ADMIN_CLI_VERSION=$(jq -r '.version' $ADMIN_CLI_METADATA_FILE)
           UPGRADE_TOKEN=$(kubectl exec enterprise-admin-cli --namespace=$DEPLOYMENT_ID -- gis generate-token --expiration $MAX_UPGRADE_TIME) || UPGRADE_TOKEN="token"
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/organization.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform apply -var-file=$CONFIG_FILE -var "upgrade_token=$UPGRADE_TOKEN" -var "enterprise_admin_cli_version=$ADMIN_CLI_VERSION" -auto-approve 
+          terraform apply -var-file=$CONFIG_FILE -var "upgrade_token=$UPGRADE_TOKEN" -var "enterprise_admin_cli_version=$ADMIN_CLI_VERSION" -auto-approve -input=false 
       - name: Retrieve Logs
         id: retrieve-logs
         env:

--- a/aws/arcgis-notebook-server-linux/README.md
+++ b/aws/arcgis-notebook-server-linux/README.md
@@ -45,8 +45,6 @@ Instructions:
 3. Commit the changes to a Git branch and push the branch to GitHub.
 4. Run the notebook-server-linux-aws-image workflow using the branch.
 
-> In the configuration files, "os" and "arcgis_version" property values for the same deployment must match across all the configuration files of the deployment.
-
 ### 2. Provision AWS Resources
 
 GitHub Actions workflow **notebook-server-linux-aws-infrastructure** creates AWS resources for ArcGIS Notebook Server deployment.

--- a/aws/arcgis-notebook-server-linux/application/README.md
+++ b/aws/arcgis-notebook-server-linux/application/README.md
@@ -48,9 +48,10 @@ The module reads the following SSM parameters:
 |--------------------|-------------|
 | /arcgis/${var.site_id}/${var.deployment_id}/backup/plan-id | Backup plan ID for the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
-| /arcgis/${var.site_id}/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the deployment |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context |
 | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL |
-| /arcgis/${var.site_id}/chef-client-url/${var.os} | Chef Client URL |
+| /arcgis/${var.site_id}/chef-client-url/${os} | Chef Client URL for the operating system |
 | /arcgis/${var.site_id}/cookbooks-url | Chef cookbooks URL |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
 | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
@@ -100,6 +101,7 @@ The module reads the following SSM parameters:
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_ssm_parameter.deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.notebook_server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.os](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.portal_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
@@ -121,7 +123,6 @@ The module reads the following SSM parameters:
 | log_level | ArcGIS Notebook Server log level | `string` | `"WARNING"` | no |
 | notebook_server_authorization_file_path | Local path of ArcGIS Notebook Server authorization file | `string` | n/a | yes |
 | notebook_server_authorization_options | Additional ArcGIS Notebook Server software authorization command line options | `string` | `""` | no |
-| os | Operating system id (rhel9\|ubuntu22\|ubuntu24) | `string` | `"rhel9"` | no |
 | portal_org_id | ArcGIS Enterprise organization Id | `string` | `null` | no |
 | portal_password | Portal for ArcGIS user password | `string` | n/a | yes |
 | portal_username | Portal for ArcGIS user name | `string` | n/a | yes |

--- a/aws/arcgis-notebook-server-linux/application/main.tf
+++ b/aws/arcgis-notebook-server-linux/application/main.tf
@@ -48,9 +48,10 @@
  * |--------------------|-------------|
  * | /arcgis/${var.site_id}/${var.deployment_id}/backup/plan-id | Backup plan ID for the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
- * | /arcgis/${var.site_id}/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context | 
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system of the deployment |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context | 
  * | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL | 
- * | /arcgis/${var.site_id}/chef-client-url/${var.os} | Chef Client URL |
+ * | /arcgis/${var.site_id}/chef-client-url/${os} | Chef Client URL for the operating system |
  * | /arcgis/${var.site_id}/cookbooks-url | Chef cookbooks URL |
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
  * | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
@@ -108,16 +109,20 @@ provider "aws" {
   }
 }
 
+data "aws_ssm_parameter" "os" {
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/os"
+}
+
+data "aws_ssm_parameter" "notebook_server_web_context" {
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context"
+}
+
 data "aws_ssm_parameter" "deployment_fqdn" {
   name = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn"
 }
 
-data "aws_ssm_parameter" "notebook_server_web_context" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/notebook-server-web-context"
-}
-
 data "aws_ssm_parameter" "portal_url" {
-  name  = "/arcgis/${var.site_id}/${var.deployment_id}/portal-url"
+  name = "/arcgis/${var.site_id}/${var.deployment_id}/portal-url"
 }
 
 # Retrieve attributes of the primary EC2 instance
@@ -181,14 +186,15 @@ locals {
   authorization_files_s3_prefix = "software/authorization/${var.arcgis_version}"
   certificates_s3_prefix        = "software/certificates"
 
-  mount_point             = "/mnt/efs"
-  deployment_fqdn         = nonsensitive(data.aws_ssm_parameter.deployment_fqdn.value)
+  mount_point                 = "/mnt/efs"
+  deployment_fqdn             = nonsensitive(data.aws_ssm_parameter.deployment_fqdn.value)
+  os                          = nonsensitive(data.aws_ssm_parameter.os.value)
   notebook_server_web_context = nonsensitive(data.aws_ssm_parameter.notebook_server_web_context.value)
-  portal_url              = nonsensitive(data.aws_ssm_parameter.portal_url.value)
-  primary_hostname        = data.aws_instance.primary.private_ip
-  software_dir            = "/opt/software/setups/*"
-  authorization_files_dir = "/opt/software/authorization"
-  certificates_dir        = "/opt/software/certificates"
+  portal_url                  = nonsensitive(data.aws_ssm_parameter.portal_url.value)
+  primary_hostname            = data.aws_instance.primary.private_ip
+  software_dir                = "/opt/software/setups/*"
+  authorization_files_dir     = "/opt/software/authorization"
+  certificates_dir            = "/opt/software/certificates"
 
   keystore_file = var.keystore_file_path != null ? "${local.certificates_dir}/${basename(var.keystore_file_path)}" : ""
   root_cert     = var.root_cert_file_path != null ? "${local.certificates_dir}/${basename(var.root_cert_file_path)}" : ""
@@ -212,7 +218,7 @@ module "s3_copy_files" {
 # Install Chef Client and Chef Cookbooks for ArcGIS on all EC2 instances of the deployment
 module "bootstrap_deployment" {
   source           = "../../modules/bootstrap"
-  os               = var.os
+  os               = local.os
   site_id          = var.site_id
   deployment_id    = var.deployment_id
   machine_roles    = ["primary", "node"]
@@ -557,7 +563,7 @@ module "arcgis_notebook_server_primary" {
 
 # Configure ArcGIS Notebook Server on node EC2 instances if any
 module "arcgis_notebook_server_node" {
-  count = length(data.aws_instances.nodes.ids) > 0 ? 1 : 0
+  count          = length(data.aws_instances.nodes.ids) > 0 ? 1 : 0
   source         = "../../modules/run_chef"
   parameter_name = "/arcgis/${var.site_id}/attributes/${var.deployment_id}/arcgis-notebook-server/node"
   site_id        = var.site_id
@@ -627,7 +633,7 @@ module "arcgis_notebook_server_federation" {
       }
       notebook_server = {
         web_context_url = "https://${local.deployment_fqdn}/${local.notebook_server_web_context}"
-        private_url     = "https://${local.deployment_fqdn}:11443/arcgis"
+        private_url     = "https://${local.deployment_fqdn}/${local.notebook_server_web_context}"
         admin_username  = var.admin_username
         admin_password  = var.admin_password
       }

--- a/aws/arcgis-notebook-server-linux/application/variables.tf
+++ b/aws/arcgis-notebook-server-linux/application/variables.tf
@@ -101,6 +101,11 @@ variable "keystore_file_path" {
   description = "Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.keystore_file_path == null || try(fileexists(var.keystore_file_path), false)
+    error_message = "The keystore_file_path value must be a valid file path."
+  }  
 }
 
 variable "license_level" {
@@ -127,6 +132,11 @@ variable "log_level" {
 variable "notebook_server_authorization_file_path" {
   description = "Local path of ArcGIS Notebook Server authorization file"
   type        = string
+
+  validation {
+    condition     = fileexists(var.notebook_server_authorization_file_path)
+    error_message = "The notebook_server_authorization_file_path value must be a valid file path."
+  }
 }
 
 variable "notebook_server_authorization_options" {
@@ -134,17 +144,6 @@ variable "notebook_server_authorization_options" {
   type        = string
   sensitive   = true
   default     = ""
-}
-
-variable "os" {
-  description = "Operating system id (rhel9|ubuntu22|ubuntu24)"
-  type        = string
-  default     = "rhel9"
-
-  validation {
-    condition     = contains(["rhel9", "ubuntu22", "ubuntu24"], var.os)
-    error_message = "Valid values for os variable are rhel9, ubuntu22, and ubuntu24."
-  }
 }
 
 variable "portal_org_id" {
@@ -168,6 +167,11 @@ variable "root_cert_file_path" {
   description = "Local path of root certificate file in PEM format used by ArcGIS Server and Portal for ArcGIS"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.root_cert_file_path == null || try(fileexists(var.root_cert_file_path), false)
+    error_message = "The root_cert_file_path value must be a valid file path."
+  }  
 }
 
 variable "run_as_user" {

--- a/aws/arcgis-notebook-server-linux/image/README.md
+++ b/aws/arcgis-notebook-server-linux/image/README.md
@@ -28,9 +28,9 @@ On the machine where Packer is executed:
 
 * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
 * Path to aws/scripts directory must be added to PYTHONPATH
-* AWS credentials must be configured.
-
-My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+* AWS CLI must be installed and configured
+* AWS credentials must be configured
+* My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
 
 ## SSM Parameters
 
@@ -51,8 +51,10 @@ The template writes the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
-| /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI Id |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node AMI Id |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context | Notebook Server web context name |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system identifier |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI Id |
 
 ## Inputs
 

--- a/aws/arcgis-notebook-server-linux/image/main.pkr.hcl
+++ b/aws/arcgis-notebook-server-linux/image/main.pkr.hcl
@@ -29,8 +29,9 @@
  * 
  * * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
  * * Path to aws/scripts directory must be added to PYTHONPATH
- * * AWS credentials must be configured.
- * * My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+ * * AWS CLI must be installed and configured
+ * * AWS credentials must be configured
+ * * My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
  * 
  * ## SSM Parameters
  * 
@@ -51,11 +52,13 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
- * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI Id |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node AMI Id |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context | Notebook Server web context name |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system identifier |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI Id |
  */
 
-# Copyright 2025 Esri
+# Copyright 2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -388,5 +391,14 @@ build {
     }
 
     command = "python -m publish_artifact -p /arcgis/${var.site_id}/images/${var.deployment_id}/node -f packer-manifest.json -r ${build.PackerRunUUID}"
+  }
+
+    # Save os and notebook_server_web_context in SSM parameters for later use in deployment.
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/os --value ${var.os} --type String --region ${var.aws_region}"
+  }
+
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context --value ${var.notebook_server_web_context} --type String --region ${var.aws_region}"
   }
 }

--- a/aws/arcgis-notebook-server-linux/infrastructure/README.md
+++ b/aws/arcgis-notebook-server-linux/infrastructure/README.md
@@ -60,6 +60,7 @@ The module reads the following SSM parameters:
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node EC2 instances AMI ID |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context |
 | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
 | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -73,7 +74,6 @@ The module writes the following SSM parameters:
 |--------------------|-------------|
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-url | ArcGIS Notebook Server URL |
-| /arcgis/${var.site_id}/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context |
 | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group ID |
 | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL |
 
@@ -91,7 +91,6 @@ The module writes the following SSM parameters:
 | dashboard | ../../modules/dashboard | n/a |
 | efs_mount | ../../modules/efs_mount | n/a |
 | notebook_server_https_alb_target | ../../modules/alb_target_group | n/a |
-| private_server_https_alb_target | ../../modules/alb_target_group | n/a |
 | security_group | ../../modules/security_group | n/a |
 | site_core_info | ../../modules/site_core_info | n/a |
 
@@ -111,7 +110,6 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.backup_plan_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.deployment_fqdn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.deployment_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.notebook_server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.portal_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ami.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
@@ -122,6 +120,7 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.backup_role_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.backup_vault_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.node_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.notebook_server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.portal_deployment_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.primary_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
@@ -137,7 +136,6 @@ The module writes the following SSM parameters:
 | instance_type | EC2 instance type | `string` | `"m7i.2xlarge"` | no |
 | key_name | EC2 key pair name | `string` | n/a | yes |
 | node_count | Number of node EC2 instances | `number` | `1` | no |
-| notebook_server_web_context | ArcGIS Notebook Server web context | `string` | `"notebooks"` | no |
 | portal_deployment_id | Portal for ArcGIS deployment Id | `string` | `"enterprise-base-linux"` | no |
 | root_volume_iops | Root EBS volume IOPS of primary and standby EC2 instances | `number` | `16000` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `1024` | no |

--- a/aws/arcgis-notebook-server-linux/infrastructure/ingress.tf
+++ b/aws/arcgis-notebook-server-linux/infrastructure/ingress.tf
@@ -13,26 +13,31 @@
 # limitations under the License.
 
 data "aws_ssm_parameter" "alb_deployment_fqdn" {
-  name  = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn"
+  name = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn"
 }
 
 data "aws_ssm_parameter" "alb_security_group_id" {
-  name  = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id"
+  name = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id"
 }
 
 data "aws_ssm_parameter" "alb_arn" {
-  name  = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn"
+  name = "/arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn"
+}
+
+data "aws_ssm_parameter" "notebook_server_web_context" {
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context"
 }
 
 data "aws_lb" "alb" {
-  arn   = data.aws_ssm_parameter.alb_arn.value
+  arn = data.aws_ssm_parameter.alb_arn.value
 }
 
 locals {
-  alb_security_group_id = nonsensitive(data.aws_ssm_parameter.alb_security_group_id.value)
-  alb_arn               = nonsensitive(data.aws_ssm_parameter.alb_arn.value)
-  alb_dns_name          = nonsensitive(data.aws_lb.alb.dns_name)
-  deployment_fqdn       = nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)
+  alb_security_group_id       = nonsensitive(data.aws_ssm_parameter.alb_security_group_id.value)
+  alb_arn                     = nonsensitive(data.aws_ssm_parameter.alb_arn.value)
+  alb_dns_name                = nonsensitive(data.aws_lb.alb.dns_name)
+  deployment_fqdn             = nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)
+  notebook_server_web_context = nonsensitive(data.aws_ssm_parameter.notebook_server_web_context.value)
 }
 
 # Create Application Load Balancer target group for HTTPS port 443, attach 
@@ -40,31 +45,14 @@ locals {
 # Configure the target group to forward requests to the HTTP web context.
 module "notebook_server_https_alb_target" {
   source            = "../../modules/alb_target_group"
-  name              = substr(var.notebook_server_web_context, 0, 6)
+  name              = substr(local.notebook_server_web_context, 0, 6)
   vpc_id            = module.site_core_info.vpc_id
   alb_arn           = local.alb_arn
   protocol          = "HTTPS"
   alb_port          = 443
   instance_port     = 443
-  health_check_path = "/${var.notebook_server_web_context}/rest/info/healthcheck"
-  path_patterns     = ["/${var.notebook_server_web_context}", "/${var.notebook_server_web_context}/*"]
-  priority          = 120
-  target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.nodes : n.id])
-}
-
-# Create Application Load Balancer target group for ArcGIS Notebook Server HTTPS port 11443, attach 
-# primary and node instances to it, and add the target group to the load balancer. 
-# Configure the target group to forward requests to /arcgis HTTP contexts.
-module "private_server_https_alb_target" {
-  source            = "../../modules/alb_target_group"
-  name              = "arcgis"
-  vpc_id            = module.site_core_info.vpc_id
-  alb_arn           = local.alb_arn
-  protocol          = "HTTPS"
-  alb_port          = 11443
-  instance_port     = 11443
-  health_check_path = "/arcgis/rest/info/healthcheck"
-  path_patterns     = ["/arcgis", "/arcgis/*"]
+  health_check_path = "/${local.notebook_server_web_context}/rest/info/healthcheck"
+  web_context       = local.notebook_server_web_context
   priority          = 120
   target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.nodes : n.id])
 }

--- a/aws/arcgis-notebook-server-linux/infrastructure/main.tf
+++ b/aws/arcgis-notebook-server-linux/infrastructure/main.tf
@@ -60,6 +60,7 @@
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node EC2 instances AMI ID |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context |
  * | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  * | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -73,7 +74,6 @@
  * |--------------------|-------------|
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-url | ArcGIS Notebook Server URL |
- * | /arcgis/${var.site_id}/${var.deployment_id}/notebook-server-web-context | ArcGIS Notebook Server web context |
  * | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group ID |
  * | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL |
  */
@@ -120,7 +120,6 @@ provider "aws" {
 }
 
 # Retrieve configuration parameters from SSM Parameter Store
-
 data "aws_ssm_parameter" "primary_ami" {
   name = "/arcgis/${var.site_id}/images/${var.deployment_id}/primary"
 }
@@ -346,17 +345,10 @@ resource "aws_ssm_parameter" "deployment_fqdn" {
   description = "Fully qualified domain name of the deployment"
 }
 
-resource "aws_ssm_parameter" "notebook_server_web_context" {
-  name        = "/arcgis/${var.site_id}/${var.deployment_id}/notebook-server-web-context"
-  type        = "String"
-  value       = var.notebook_server_web_context
-  description = "ArcGIS Notebook Server web context"
-}
-
 resource "aws_ssm_parameter" "deployment_url" {
   name        = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-url"
   type        = "String"
-  value       = "https://${local.deployment_fqdn}/${var.notebook_server_web_context}"
+  value       = "https://${local.deployment_fqdn}/${local.notebook_server_web_context}"
   description = "ArcGIS Notebook Server URL"
 }
 

--- a/aws/arcgis-notebook-server-linux/infrastructure/outputs.tf
+++ b/aws/arcgis-notebook-server-linux/infrastructure/outputs.tf
@@ -19,5 +19,5 @@ output "security_group_id" {
 
 output "deployment_url" {
   description = "ArcGIS Notebook Server URL"
-  value       = "https://${local.deployment_fqdn}/${var.notebook_server_web_context}"
+  value       = "https://${local.deployment_fqdn}/${local.notebook_server_web_context}"
 }

--- a/aws/arcgis-notebook-server-linux/infrastructure/variables.tf
+++ b/aws/arcgis-notebook-server-linux/infrastructure/variables.tf
@@ -73,12 +73,6 @@ variable "node_count" {
   }
 }
 
-variable "notebook_server_web_context" {
-  description = "ArcGIS Notebook Server web context"
-  type        = string
-  default     = "notebooks"
-}
-
 variable "portal_deployment_id" {
   description = "Portal for ArcGIS deployment Id"
   type        = string

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-application.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-application.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Esri
+# Copyright 2025-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Output
       id: output  
       run: echo arcgis_notebook_server_url=$(terraform output arcgis_notebook_server_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-destroy.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-destroy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Esri
+# Copyright 2025-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Link Config Directory
+        run: ln -s ${{ github.workspace }}/config ~/config
       - name: Install boto3
         id: install-boto3
         run: pip install boto3
@@ -60,7 +62,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve -input=false
       - name: Destroy Infrastructure
         id: infrastructure-destroy
         working-directory: aws/arcgis-notebook-server-linux/infrastructure
@@ -68,7 +70,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
       - name: Delete AMIs
         id: delete-amis
         run: |

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-infrastructure.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-infrastructure.yaml
@@ -65,11 +65,11 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: github.event.inputs.terraform_command != 'plan'
-      run: terraform apply -var-file $CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: github.event.inputs.terraform_command == 'plan'
-      run: terraform plan -var-file $CONFIG_FILE 
+      run: terraform plan -var-file $CONFIG_FILE -input=false 
     - name: Terraform Output
       id: output  
       run: echo deployment_url=$(terraform output deployment_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-recover.yaml
+++ b/aws/arcgis-notebook-server-linux/workflows/notebook-server-linux-aws-recover.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Esri
+# Copyright 2025-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: ${{ inputs.test_mode == false }}
-      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: ${{ inputs.test_mode == true }}

--- a/aws/arcgis-server-linux/README.md
+++ b/aws/arcgis-server-linux/README.md
@@ -58,8 +58,6 @@ Instructions:
 3. Commit the changes to a Git branch and push the branch to GitHub.
 4. Run server-linux-aws-image workflow using the branch.
 
-> In the configuration files, "os" and "arcgis_version" property values for the same deployment must match across all the configuration files of the deployment.
-
 ### 3. Provision AWS Resources
 
 GitHub Actions workflow **server-linux-aws-infrastructure** creates AWS resources for ArcGIS Server deployment.

--- a/aws/arcgis-server-linux/application/README.md
+++ b/aws/arcgis-server-linux/application/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Application Terraform Module for ArcGIS Server on Linux
 
-The Terraform module configures or upgrades applications of ArcGIS Server deployment on the Linux platforms.
+The Terraform module configures or upgrades applications for an ArcGIS Server deployment on the Linux platforms.
 
 ![ArcGIS Server on Linux](arcgis-server-linux-application.png "ArcGIS Server on Linux")
 
@@ -37,8 +37,8 @@ On the machine where Terraform is executed:
 * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
 * Path to aws/scripts directory must be added to PYTHONPATH
 * Ansible 2.16 or later must be installed
-* arcgis.common, arcgis.server, and arcgis.portal Ansible collections must be installed
-* The working directury must be set to the arcgis-server-linux/application module path
+* arcgis.common, arcgis.server, arcgis.portal, and arcgis.webadaptor Ansible collections must be installed
+* The working directory must be set to the arcgis-server-linux/application module path
 * AWS credentials must be configured
 
 My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
@@ -53,8 +53,8 @@ The module reads the following SSM parameters:
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
 | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL (if server_role input variable is specified) |
-| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
 | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -122,7 +122,6 @@ The module reads the following SSM parameters:
 | keystore_file_password | Password for keystore file with SSL certificate used by HTTPS listeners | `string` | `""` | no |
 | keystore_file_path | Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners | `string` | `null` | no |
 | log_level | ArcGIS Enterprise applications log level | `string` | `"WARNING"` | no |
-| os | Operating system id (rhel8\|rhel9) | `string` | `"rhel9"` | no |
 | portal_org_id | ArcGIS Enterprise organization Id | `string` | `null` | no |
 | portal_password | Portal for ArcGIS user password | `string` | `null` | no |
 | portal_username | Portal for ArcGIS user name | `string` | `null` | no |

--- a/aws/arcgis-server-linux/application/main.tf
+++ b/aws/arcgis-server-linux/application/main.tf
@@ -1,7 +1,7 @@
 /**
  * # Application Terraform Module for ArcGIS Server on Linux
  *
- * The Terraform module configures or upgrades applications of ArcGIS Server deployment on the Linux platforms.
+ * The Terraform module configures or upgrades applications for an ArcGIS Server deployment on the Linux platforms.
  *
  * ![ArcGIS Server on Linux](arcgis-server-linux-application.png "ArcGIS Server on Linux")
  *
@@ -37,8 +37,8 @@
  * * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
  * * Path to aws/scripts directory must be added to PYTHONPATH
  * * Ansible 2.16 or later must be installed
- * * arcgis.common, arcgis.server, and arcgis.portal Ansible collections must be installed
- * * The working directury must be set to the arcgis-server-linux/application module path
+ * * arcgis.common, arcgis.server, arcgis.portal, and arcgis.webadaptor Ansible collections must be installed
+ * * The working directory must be set to the arcgis-server-linux/application module path
  * * AWS credentials must be configured
  *
  * My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
@@ -53,8 +53,8 @@
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
  * | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL (if server_role input variable is specified) | 
- * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context | 
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context | 
  * | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  * | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -113,7 +113,7 @@ data "aws_ssm_parameter" "deployment_fqdn" {
 }
 
 data "aws_ssm_parameter" "server_web_context" {
-  name = "/arcgis/${var.site_id}/${var.deployment_id}/server-web-context"
+  name = "/arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context"
 }
 
 data "aws_ssm_parameter" "portal_url" {

--- a/aws/arcgis-server-linux/application/variables.tf
+++ b/aws/arcgis-server-linux/application/variables.tf
@@ -105,17 +105,6 @@ variable "log_level" {
   }
 }
 
-variable "os" {
-  description = "Operating system id (rhel8|rhel9)"
-  type        = string
-  default     = "rhel9"
-
-  validation {
-    condition     = contains(["rhel9"], var.os)
-    error_message = "Valid values for os variable are rhel9."
-  }
-}
-
 variable "portal_org_id" {
   description = "ArcGIS Enterprise organization Id"
   type        = string
@@ -144,6 +133,11 @@ variable "run_as_user" {
 variable "server_authorization_file_path" {
   description = "Local path of ArcGIS Server authorization file"
   type        = string
+
+  validation {
+    condition     = fileexists(var.server_authorization_file_path)
+    error_message = "The server_authorization_file_path value must be a valid file path."
+  }  
 }
 
 variable "server_authorization_options" {
@@ -210,6 +204,11 @@ variable "keystore_file_path" {
   description = "Local path of keystore file in PKCS12 format with SSL certificate used by HTTPS listeners"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.keystore_file_path == null || try(fileexists(var.keystore_file_path), false)
+    error_message = "The keystore_file_path value must be a valid file path."
+  }  
 }
 
 variable "keystore_file_password" {
@@ -223,4 +222,9 @@ variable "root_cert_file_path" {
   description = "Local path of root certificate file in PEM format used by ArcGIS Server"
   type        = string
   default     = null
+
+  validation {
+    condition     = var.root_cert_file_path == null || try(fileexists(var.root_cert_file_path), false)
+    error_message = "The root_cert_file_path value must be a valid file path."
+  }
 }

--- a/aws/arcgis-server-linux/backup/main.tf
+++ b/aws/arcgis-server-linux/backup/main.tf
@@ -19,7 +19,7 @@
  * The module retrieves the backup S3 bucket name from '/arcgis/${var.site_id}/s3/backup' SSM parameters.
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-server-linux/image/README.md
+++ b/aws/arcgis-server-linux/image/README.md
@@ -1,6 +1,6 @@
 # Packer Template for ArcGIS Server on Linux AMI
 
-The Packer templates builds EC2 AMI for a specific ArcGIS Server Enterprise deployment.
+The Packer template builds EC2 AMI for a specific ArcGIS Server Enterprise deployment.
 
 The AMI is built from a Linux OS base image specified by SSM parameter "/arcgis/${var.site_id}/images/${var.os}".
 
@@ -8,7 +8,7 @@ The AMI is built from a Linux OS base image specified by SSM parameter "/arcgis/
 
 The template first copies installation media for the ArcGIS Server version and required third party dependencies from My Esri and public repositories to the private repository S3 bucket. The files to be copied are  specified in ../manifests/arcgis-server-s3files-${var.arcgis_version}.json index file.
 
-Then the template uses python scripts to run SSM commands on the source EC2 instance to:
+Then the template uses Python scripts to run SSM commands on the source EC2 instance to:
 
 1. Install AWS CLI
 2. Install CloudWatch Agent
@@ -31,10 +31,10 @@ On the machine where Packer is executed:
 * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
 * Path to aws/scripts directory must be added to PYTHONPATH
 * Ansible 2.16 or later must be installed
-* arcgis.common and arcgis.server Ansible collections must be installed
-* AWS credentials must be configured.
-
-My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
+* arcgis.common, arcgis.server, and arcgis.webadaptor Ansible collections must be installed
+* AWS CLI must be installed and configured
+* AWS credentials must be configured
+* My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
 
 ## SSM Parameters
 
@@ -43,25 +43,34 @@ The template uses the following SSM parameters:
 | SSM parameter name | Description |
 |--------------------|-------------|
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
-| /arcgis/${var.site_id}/images/${var.os} | Source AMI Id|
+| /arcgis/${var.site_id}/images/${var.os} | Source AMI ID|
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM commands output |
 | /arcgis/${var.site_id}/s3/region | S3 buckets region code |
 | /arcgis/${var.site_id}/s3/repository | Private repository S3 bucket |
-| /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
+| /arcgis/${var.site_id}/vpc/subnets | IDs of VPC subnets |
+
+The template writes the following SSM parameters:
+
+| SSM parameter name | Description |
+|--------------------|-------------|
+| /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node AMI ID |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context name |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system identifier |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI ID |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws_region | AWS region Id | `string` | `env("AWS_DEFAULT_REGION")` | no |
+| aws_region | AWS region ID | `string` | `env("AWS_DEFAULT_REGION")` | no |
 | arcgis_server_patches | File names of ArcGIS Server patches to install | `string` | `[]` | no |
 | arcgis_version | ArcGIS Server version | `string` | `"12.0"` | no |
-| deployment_id | Deployment Id | `string` | `"server-linux"` | no |
+| deployment_id | Deployment ID | `string` | `"server-linux"` | no |
 | instance_type | EC2 instance type | `string` | `"m6i.2xlarge"` | no |
-| os | Operating system | `string` | `"rhel9"` | no |
+| os | Operating system ID | `string` | `"rhel9"` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `100` | no |
 | run_as_user | User account used to run ArcGIS Server | `string` | `"arcgis"` | no |
-| site_id | ArcGIS site Id | `string` | `"arcgis"` | no |
+| site_id | ArcGIS site ID | `string` | `"arcgis"` | no |
 | skip_create_ami | If true, Packer will not create the AMI | `bool` | `false` | no |
 | use_webadaptor | If true, OpenJDK, Apache Tomcat, and ArcGIS Web Adaptor will be installed on the AMI. | `bool` | `false` | no |
 | server_web_context | ArcGIS Web Adaptor name | `string` | `"arcgis"` | no |

--- a/aws/arcgis-server-linux/image/main.pkr.hcl
+++ b/aws/arcgis-server-linux/image/main.pkr.hcl
@@ -1,7 +1,7 @@
 /**
  * # Packer Template for ArcGIS Server AMI
  * 
- * The Packer templates builds EC2 AMI for a specific ArcGIS Server deployment.
+ * The Packer template builds EC2 AMI for a specific ArcGIS Server deployment.
  * 
  * The AMI is built from the operating system's base image specified by SSM parameter "/arcgis/${var.site_id}/images/${var.os}".
  * 
@@ -12,7 +12,7 @@
  * to the private repository S3 bucket. The files to be copied are specified in 
  * ../manifests/arcgis-server-s3files-${var.arcgis_version}.json index file.
  * 
- * Then the template uses python scripts to run SSM commands on the source EC2 instance to:
+ * Then the template uses Python scripts to run SSM commands on the source EC2 instance to:
  * 
  * 1. Install CloudWatch Agent
  * 2. Download setups from the private repository S3 bucket.
@@ -32,12 +32,15 @@
  * ## Requirements
  * 
  * On the machine where Packer is executed:
- * 
+ *
  * * Python 3.8 or later with [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) package must be installed
  * * Path to aws/scripts directory must be added to PYTHONPATH
- * * AWS credentials must be configured.
- * * My Esri user name and password must be specified either using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or the input variables.
- * 
+ * * Ansible 2.16 or later must be installed
+ * * arcgis.common, arcgis.server, and arcgis.webadaptor Ansible collections must be installed
+ * * AWS CLI must be installed and configured
+ * * AWS credentials must be configured
+ * * My Esri user name and password must be specified using environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD
+ *
  * ## SSM Parameters
  * 
  * The template uses the following SSM parameters:
@@ -45,14 +48,23 @@
  * | SSM parameter name | Description |
  * |--------------------|-------------|
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name|
- * | /arcgis/${var.site_id}/images/${var.os} | Source AMI Id|
+ * | /arcgis/${var.site_id}/images/${var.os} | Source AMI ID|
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM commands output |
  * | /arcgis/${var.site_id}/s3/region | S3 buckets region code |
  * | /arcgis/${var.site_id}/s3/repository | Private repository S3 bucket |
- * | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
+ * | /arcgis/${var.site_id}/vpc/subnets | IDs of VPC subnets |
+ *
+ * The template writes the following SSM parameters:
+ *
+ * | SSM parameter name | Description |
+ * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node AMI ID |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context name |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/os | Operating system identifier |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary AMI ID |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -264,7 +276,7 @@ build {
     ]
   }
 
-  # Download setups from private S3 repository and install ArcGIS Web Aaptor
+  # Download setups from private S3 repository and install ArcGIS Web Adaptor
   provisioner "shell-local" {
     env = {
       AWS_DEFAULT_REGION = var.aws_region
@@ -310,5 +322,14 @@ build {
     }
 
     command = "python -m publish_artifact -p /arcgis/${var.site_id}/images/${var.deployment_id}/node -f packer-manifest.json -r ${build.PackerRunUUID}"
+  }
+
+  # Save os and server_web_context in SSM parameters for later use in deployment.
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/os --value ${var.os} --type String --region ${var.aws_region}"
+  }
+
+  post-processor "shell-local" {
+    command = "aws ssm put-parameter --name /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context --value ${var.server_web_context} --type String --region ${var.aws_region}"
   }
 }

--- a/aws/arcgis-server-linux/image/variables.pkr.hcl
+++ b/aws/arcgis-server-linux/image/variables.pkr.hcl
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
  
 variable "aws_region" {
-  description = "AWS region Id"
+  description = "AWS region ID"
   type        = string
   default     = env("AWS_DEFAULT_REGION")
 }
@@ -36,7 +36,7 @@ variable "arcgis_version" {
 }
 
 variable "deployment_id" {
-  description = "Deployment Id"
+  description = "Deployment ID"
   type        = string
   default     = "server-linux"
 
@@ -53,7 +53,7 @@ variable "instance_type" {
 }
 
 variable "os" {
-  description = "Operating system Id (rhel9)"
+  description = "Operating system ID (rhel9)"
   type        = string
   default     = "rhel9"
 
@@ -81,7 +81,7 @@ variable "run_as_user" {
 }
 
 variable "site_id" {
-  description = "ArcGIS Enterprise site Id"
+  description = "ArcGIS Enterprise site ID"
   type        = string
   default     = "arcgis"
 

--- a/aws/arcgis-server-linux/infrastructure/README.md
+++ b/aws/arcgis-server-linux/infrastructure/README.md
@@ -54,7 +54,6 @@ The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
-| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ALB ARN |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | ALB security group ID |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the base ArcGIS Enterprise deployment |
@@ -64,6 +63,7 @@ The module reads the following SSM parameters:
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node EC2 instances AMI ID |
 | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+| /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
 | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
 | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |
@@ -151,7 +151,7 @@ The module writes the following SSM parameters:
 | root_volume_throughput | Root EBS volume throughput in MB/s of primary and standby EC2 instances | `number` | `125` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis"` | no |
 | subnet_ids | EC2 instances subnet IDs (by default, the first two private VPC subnets are used) | `list(string)` | `[]` | no |
-| use_webadaptor | If true, port 443 is used as the instance HTTPS port, otherwise 6443 bis used. | `bool` | `false` | no |
+| use_webadaptor | If true, port 443 is used as the instance HTTPS port, otherwise 6443 is used. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/aws/arcgis-server-linux/infrastructure/README.md
+++ b/aws/arcgis-server-linux/infrastructure/README.md
@@ -5,7 +5,7 @@ The Terraform module provisions AWS resources for ArcGIS Server deployment on th
 
 ![Infrastructure for ArcGIS Server on Linux](arcgis-server-linux-infrastructure.png "Infrastructure for ArcGIS Server on Linux")  
 
-The module launches one primary SSM-managed EC2 instance and node_count node instances
+The module launches one primary SSM-managed EC2 instance and node_count additional instances
 in the private VPC subnets or subnets specified by the subnet_ids input variable.
 The instances are launched from images retrieved from '/arcgis/${var.site_id}/images/${var.deployment_id}/{instance role}' SSM parameters.
 The images must be created by the Packer Template for ArcGIS Server on Linux AMI.
@@ -54,10 +54,11 @@ The module reads the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
+| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ALB ARN |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | ALB security group ID |
 | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the base ArcGIS Enterprise deployment |
-| /arcgis/${var.site_id}/${var.portal_deployment_id}/deployment-url | Deployment ID of Portal for ArcGIS (if portal_deployment_id is set) |
+| /arcgis/${var.site_id}/${var.portal_deployment_id}/deployment-url | Deployment URL of Portal for ArcGIS (if portal_deployment_id is set) |
 | /arcgis/${var.site_id}/backup/vault-name | Name of the AWS Backup vault |
 | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
 | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
@@ -74,13 +75,12 @@ The module writes the following SSM parameters:
 
 | SSM parameter name | Description |
 |--------------------|-------------|
-| /arcgis/${var.site_id}/${var.deployment_id}/backup-plan-id | Backup plan ID for the deployment |
+| /arcgis/${var.site_id}/${var.deployment_id}/backup/plan-id | Backup plan ID for the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
 | /arcgis/${var.site_id}/${var.deployment_id}/deployment-url | ArcGIS Server URL |
 | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
 | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL |
 | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group ID |
-| /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
 
 ## Providers
 
@@ -121,7 +121,6 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.object_store_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.portal_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ami.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_lb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
 | [aws_ssm_parameter.alb_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
@@ -132,6 +131,7 @@ The module writes the following SSM parameters:
 | [aws_ssm_parameter.node_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.portal_deployment_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.primary_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.server_web_context](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 
@@ -149,7 +149,6 @@ The module writes the following SSM parameters:
 | root_volume_iops | Root EBS volume IOPS of primary and standby EC2 instances | `number` | `3000` | no |
 | root_volume_size | Root EBS volume size in GB | `number` | `1024` | no |
 | root_volume_throughput | Root EBS volume throughput in MB/s of primary and standby EC2 instances | `number` | `125` | no |
-| server_web_context | ArcGIS Server web context | `string` | `"arcgis"` | no |
 | site_id | ArcGIS Enterprise site Id | `string` | `"arcgis"` | no |
 | subnet_ids | EC2 instances subnet IDs (by default, the first two private VPC subnets are used) | `list(string)` | `[]` | no |
 | use_webadaptor | If true, port 443 is used as the instance HTTPS port, otherwise 6443 bis used. | `bool` | `false` | no |

--- a/aws/arcgis-server-linux/infrastructure/main.tf
+++ b/aws/arcgis-server-linux/infrastructure/main.tf
@@ -5,7 +5,7 @@
  *
  * ![Infrastructure for ArcGIS Server on Linux](arcgis-server-linux-infrastructure.png "Infrastructure for ArcGIS Server on Linux")  
  *
- * The module launches one primary SSM-managed EC2 instance and node_count node instances 
+ * The module launches one primary SSM-managed EC2 instance and node_count additional instances 
  * in the private VPC subnets or subnets specified by the subnet_ids input variable.
  * The instances are launched from images retrieved from '/arcgis/${var.site_id}/images/${var.deployment_id}/{instance role}' SSM parameters. 
  * The images must be created by the Packer Template for ArcGIS Server on Linux AMI. 
@@ -54,10 +54,11 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
+ * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ALB ARN |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | ALB security group ID |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the base ArcGIS Enterprise deployment |
- * | /arcgis/${var.site_id}/${var.portal_deployment_id}/deployment-url | Deployment ID of Portal for ArcGIS (if portal_deployment_id is set) |
+ * | /arcgis/${var.site_id}/${var.portal_deployment_id}/deployment-url | Deployment URL of Portal for ArcGIS (if portal_deployment_id is set) |
  * | /arcgis/${var.site_id}/backup/vault-name | Name of the AWS Backup vault |
  * | /arcgis/${var.site_id}/iam/backup-role-arn | ARN of IAM role used by AWS Backup service |
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
@@ -74,13 +75,12 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
- * | /arcgis/${var.site_id}/${var.deployment_id}/backup-plan-id | Backup plan ID for the deployment | 
+ * | /arcgis/${var.site_id}/${var.deployment_id}/backup/plan-id | Backup plan ID for the deployment | 
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-fqdn | Fully qualified domain name of the deployment |
  * | /arcgis/${var.site_id}/${var.deployment_id}/deployment-url | ArcGIS Server URL |
  * | /arcgis/${var.site_id}/${var.deployment_id}/object-store-s3-bucket | S3 bucket for the object store |
  * | /arcgis/${var.site_id}/${var.deployment_id}/portal-url | Portal for ArcGIS URL |
  * | /arcgis/${var.site_id}/${var.deployment_id}/security-group-id | Deployment security group ID |
- * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  */
 
 # Copyright 2024-2026 Esri
@@ -139,6 +139,10 @@ data "aws_ssm_parameter" "portal_deployment_url" {
   name = "/arcgis/${var.site_id}/${var.portal_deployment_id}/deployment-url"
 }
 
+data "aws_ssm_parameter" "server_web_context" {
+  name  = "/arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context"
+}
+
 data "aws_ami" "ami" {
   filter {
     name   = "image-id"
@@ -172,6 +176,7 @@ locals {
   alb_arn               = nonsensitive(data.aws_ssm_parameter.alb_arn.value)
   alb_dns_name          = data.aws_lb.alb.dns_name
   deployment_fqdn       = nonsensitive(data.aws_ssm_parameter.alb_deployment_fqdn.value)
+  server_web_context    = nonsensitive(data.aws_ssm_parameter.server_web_context.value)
 }
 
 module "site_core_info" {
@@ -320,14 +325,14 @@ resource "aws_instance" "nodes" {
 # Configure the target group to forward requests to the HTTP web context.
 module "server_https_alb_target" {
   source            = "../../modules/alb_target_group"
-  name              = substr(var.server_web_context, 0, 6)
+  name              = substr(local.server_web_context, 0, 6)
   vpc_id            = module.site_core_info.vpc_id
   alb_arn           = local.alb_arn
   protocol          = "HTTPS"
   alb_port          = 443
   instance_port     = var.use_webadaptor ? 443 : 6443
-  health_check_path = "/${var.server_web_context}/rest/info/healthcheck"
-  path_patterns     = ["/${var.server_web_context}", "/${var.server_web_context}/*"]
+  health_check_path = "/${local.server_web_context}/rest/info/healthcheck"
+  web_context       = local.server_web_context
   priority          = 110
   target_instances  = concat([aws_instance.primary.id], [for n in aws_instance.nodes : n.id])
 }
@@ -425,17 +430,10 @@ resource "aws_ssm_parameter" "deployment_fqdn" {
   description = "Fully qualified domain name of the deployment"
 }
 
-resource "aws_ssm_parameter" "server_web_context" {
-  name        = "/arcgis/${var.site_id}/${var.deployment_id}/server-web-context"
-  type        = "String"
-  value       = var.server_web_context
-  description = "ArcGIS Server web context"
-}
-
 resource "aws_ssm_parameter" "deployment_url" {
   name        = "/arcgis/${var.site_id}/${var.deployment_id}/deployment-url"
   type        = "String"
-  value       = "https://${local.deployment_fqdn}/${var.server_web_context}"
+  value       = "https://${local.deployment_fqdn}/${local.server_web_context}"
   description = "URL of the deployment"
 }
 

--- a/aws/arcgis-server-linux/infrastructure/main.tf
+++ b/aws/arcgis-server-linux/infrastructure/main.tf
@@ -54,7 +54,6 @@
  *
  * | SSM parameter name | Description |
  * |--------------------|-------------|
- * | /arcgis/${var.site_id}/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/arn | ALB ARN |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/alb/security-group-id | ALB security group ID |
  * | /arcgis/${var.site_id}/${var.ingress_deployment_id}/deployment-fqdn | Fully qualified domain name of the base ArcGIS Enterprise deployment |
@@ -64,6 +63,7 @@
  * | /arcgis/${var.site_id}/iam/instance-profile-name | IAM instance profile name |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/node | Node EC2 instances AMI ID |
  * | /arcgis/${var.site_id}/images/${var.deployment_id}/primary | Primary EC2 instance AMI ID |
+ * | /arcgis/${var.site_id}/images/${var.deployment_id}/server-web-context | ArcGIS Server web context |
  * | /arcgis/${var.site_id}/s3/backup | S3 bucket for the backup |
  * | /arcgis/${var.site_id}/s3/logs | S3 bucket for SSM command output |
  * | /arcgis/${var.site_id}/s3/repository | S3 bucket for the private repository |

--- a/aws/arcgis-server-linux/infrastructure/outputs.tf
+++ b/aws/arcgis-server-linux/infrastructure/outputs.tf
@@ -19,5 +19,5 @@ output "security_group_id" {
 
 output "deployment_url" {
   description = "ArcGIS Server URL"
-  value       = "https://${local.deployment_fqdn}/${var.server_web_context}"
+  value       = "https://${local.deployment_fqdn}/${local.server_web_context}"
 }

--- a/aws/arcgis-server-linux/infrastructure/variables.tf
+++ b/aws/arcgis-server-linux/infrastructure/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ variable "subnet_ids" {
 }
 
 variable "use_webadaptor" {
-  description = "If true, port 443 is used as the instance HTTPS port, otherwise 6443 bis used."
+  description = "If true, port 443 is used as the instance HTTPS port, otherwise 6443 is used."
   type        = bool
   default     = false
 }

--- a/aws/arcgis-server-linux/infrastructure/variables.tf
+++ b/aws/arcgis-server-linux/infrastructure/variables.tf
@@ -129,17 +129,6 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "server_web_context" {
-  description = "ArcGIS Server web context"
-  type        = string
-  default     = "arcgis"
-
-  validation {
-    condition = var.use_webadaptor == true || var.server_web_context == "arcgis"
-    error_message = "The server_web_context value must be 'arcgis' if use_webadaptor is set to false."
-  }
-}
-
 variable "use_webadaptor" {
   description = "If true, port 443 is used as the instance HTTPS port, otherwise 6443 bis used."
   type        = bool

--- a/aws/arcgis-server-linux/restore/main.tf
+++ b/aws/arcgis-server-linux/restore/main.tf
@@ -22,7 +22,7 @@
  * '/arcgis/${var.backup_site_id}/s3/region' SSM parameters.
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-application.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Output
       id: output  
       run: echo arcgis_server_url=$(terraform output arcgis_server_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-backup.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-backup.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,4 +62,4 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/backup.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve -input=false

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-destroy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Link Config Directory
+        run: ln -s ${{ github.workspace }}/config ~/config
       - name: Install boto3
         id: install-boto3
         run: pip install boto3
@@ -58,7 +60,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $APPLICATION_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $APPLICATION_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/application.tfstate" -backend-config="region=$TF_VAR_aws_region"
-          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $APPLICATION_CONFIG_FILE -auto-approve -input=false
       - name: Destroy Infrastructure
         id: infrastructure-destroy
         working-directory: aws/arcgis-server-linux/infrastructure
@@ -66,7 +68,7 @@ jobs:
           SITE_ID=$(jq -r '.site_id' $INFRASTRUCTURE_CONFIG_FILE)
           DEPLOYMENT_ID=$(jq -r '.deployment_id' $INFRASTRUCTURE_CONFIG_FILE)
           terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/infrastructure.tfstate" -backend-config="region=$TF_VAR_aws_region" 
-          terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+          terraform destroy -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
       - name: Delete AMIs
         id: delete-amis
         run: |

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-infrastructure.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-infrastructure.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,11 +70,11 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: github.event.inputs.terraform_command != 'plan'
-      run: terraform apply -var-file $CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: github.event.inputs.terraform_command == 'plan'
-      run: terraform plan -var-file $CONFIG_FILE 
+      run: terraform plan -var-file $CONFIG_FILE -input=false 
     - name: Terraform Output
       id: output  
       run: echo deployment_url=$(terraform output deployment_url) >> $GITHUB_OUTPUT

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-recover.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-recover.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Esri
+# Copyright 2025-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,9 +74,9 @@ jobs:
     - name: Terraform Apply
       id: apply
       if: ${{ inputs.test_mode == false }}
-      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve
+      run: terraform apply -var-file $INFRASTRUCTURE_CONFIG_FILE -auto-approve -input=false
     - name: Terraform Plan
       id: plan
       if: ${{ inputs.test_mode == true }}
-      run: terraform plan -var-file $INFRASTRUCTURE_CONFIG_FILE
+      run: terraform plan -var-file $INFRASTRUCTURE_CONFIG_FILE -input=false
 

--- a/aws/arcgis-server-linux/workflows/server-linux-aws-restore.yaml
+++ b/aws/arcgis-server-linux/workflows/server-linux-aws-restore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,4 +60,4 @@ jobs:
         SITE_ID=$(jq -r '.site_id' $CONFIG_FILE)
         DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
         terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$SITE_ID/aws/$DEPLOYMENT_ID/restore.tfstate" -backend-config="region=$TF_VAR_aws_region"
-        terraform apply -var-file $CONFIG_FILE -auto-approve
+        terraform apply -var-file $CONFIG_FILE -auto-approve -input=false

--- a/aws/arcgis-site-core/automation-chef/main.tf
+++ b/aws/arcgis-site-core/automation-chef/main.tf
@@ -38,7 +38,7 @@
  * Before using the module, the repository S3 bucket must be created by infrastructure-core terraform module.
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/arcgis-site-core/ingress/variables.tf
+++ b/aws/arcgis-site-core/ingress/variables.tf
@@ -77,7 +77,7 @@ variable "http_ports" {
 variable "https_ports" {
   description = "List of HTTPS ports for the load balancer"
   type        = list(number)
-  default     = [443, 6443, 7443, 11443]
+  default     = [443]
 }
 
 variable "internal_load_balancer" {

--- a/aws/arcgis-site-core/k8s-cluster/main.tf
+++ b/aws/arcgis-site-core/k8s-cluster/main.tf
@@ -30,7 +30,7 @@
  * | /arcgis/${var.site_id}/vpc/subnets | Ids of VPC subnets |
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/alb_target_group/README.md
+++ b/aws/modules/alb_target_group/README.md
@@ -72,15 +72,15 @@ The target group is configured to forward requests for specific path patterns.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | alb_arn | Application Load Balancer ARN | `string` | n/a | yes |
-| alb_port | Target group port | `number` | `80` | no |
+| alb_port | Target group port | `number` | `443` | no |
 | health_check_path | Health check path | `string` | `"/server/rest/info/healthcheck"` | no |
-| instance_port | Instance port | `number` | `80` | no |
+| instance_port | Instance port | `number` | `443` | no |
 | name | Target group name | `string` | `null` | no |
-| path_patterns | Listener rule path patterns | `list(string)` | ```[ "/portal", "/portal/*", "/server", "/server/*" ]``` | no |
 | priority | Target group priority | `number` | `100` | no |
 | protocol | Target group protocol | `string` | `"HTTP"` | no |
 | target_instances | List of target EC2 instance Ids | `list(string)` | n/a | yes |
 | vpc_id | VPC Id | `string` | n/a | yes |
+| web_context | Web context for the service | `string` | `"arcgis"` | no |
 
 ## Outputs
 

--- a/aws/modules/alb_target_group/main.tf
+++ b/aws/modules/alb_target_group/main.tf
@@ -7,7 +7,7 @@
  *
  */
 
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,7 +63,23 @@ resource "aws_lb_listener_rule" "listener_rule" {
 
   condition {
     path_pattern {
-      values = var.path_patterns
+      values = ["/${var.web_context}", "/${var.web_context}/*"]
     }
+  }
+
+  # transform {
+  #   type = "url-rewrite"
+  #   url_rewrite_config {
+  #     rewrite {
+  #       # Matches /${var.web_context}/ followed by any path and captures it in group 1
+  #       regex   = "^/${var.web_context}/(.*)$"
+  #       # Replaces with /arcgis/ followed by the captured path group
+  #       replace = "/${var.instance_web_context}/$1"
+  #     }
+  #   }
+  # }
+
+  tags = {
+    "Name" = var.web_context
   }
 }

--- a/aws/modules/alb_target_group/variables.tf
+++ b/aws/modules/alb_target_group/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,41 @@ variable "name" {
   default     = null
 }
 
+variable "alb_arn" {
+  description = "Application Load Balancer ARN"
+  type        = string
+}
+
+variable "alb_port" {
+  description = "Target group port"
+  type        = number
+  default     = 443
+}
+
+variable "health_check_path" {
+  description = "Health check path"
+  type        = string
+  default     = "/server/rest/info/healthcheck"
+}
+
+variable "instance_port" {
+  description = "Instance port"
+  type        = number
+  default     = 443
+}
+
+# variable "instance_web_context" {
+#   description = "Web context for the instance"
+#   type        = string
+#   default     = "arcgis"
+# }
+
+variable "priority" {
+  description = "Target group priority"
+  type        = number
+  default     = 100
+}
+
 variable "protocol" {
   description = "Target group protocol"
   type        = string
@@ -29,28 +64,9 @@ variable "protocol" {
   }
 }
 
-variable "alb_port" {
-  description = "Target group port"
-  type        = number
-  default     = 80
-}
-
-variable "instance_port" {
-  description = "Instance port"
-  type        = number
-  default     = 80
-}
-
-variable "health_check_path" {
-  description = "Health check path"
-  type        = string
-  default     = "/server/rest/info/healthcheck"
-}
-
-variable "path_patterns" {
-  description = "Listener rule path patterns"
+variable "target_instances" {
+  description = "List of target EC2 instance Ids"
   type        = list(string)
-  default     = ["/portal", "/portal/*", "/server", "/server/*"]
 }
 
 variable "vpc_id" {
@@ -58,18 +74,8 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "alb_arn" {
-  description = "Application Load Balancer ARN"
+variable "web_context" {
+  description = "Web context for the service"
   type        = string
-}
-
-variable "target_instances" {
-  description = "List of target EC2 instance Ids"
-  type        = list(string)
-}
-
-variable "priority" {
-  description = "Target group priority"
-  type = number
-  default = 100
+  default     = "arcgis"
 }

--- a/aws/modules/ansible_playbook/main.tf
+++ b/aws/modules/ansible_playbook/main.tf
@@ -17,7 +17,7 @@
  * * AWS region must be specified by AWS_DEFAULT_REGION environment variable
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/bootstrap/main.tf
+++ b/aws/modules/bootstrap/main.tf
@@ -17,7 +17,7 @@
  * * AWS region must be specified by AWS_DEFAULT_REGION environment variable
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/clean_up/main.tf
+++ b/aws/modules/clean_up/main.tf
@@ -18,7 +18,7 @@
  * * AWS region must be specified by AWS_DEFAULT_REGION environment variable
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/cw_agent/main.tf
+++ b/aws/modules/cw_agent/main.tf
@@ -19,7 +19,7 @@
  * * AWS region must be specified by AWS_DEFAULT_REGION environment variable
  */
 
- # Copyright 2024 Esri
+ # Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/efs_mount/main.tf
+++ b/aws/modules/efs_mount/main.tf
@@ -17,7 +17,7 @@
  * * AWS region must be specified by AWS_DEFAULT_REGION environment variable 
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/run_chef/main.tf
+++ b/aws/modules/run_chef/main.tf
@@ -20,7 +20,7 @@
  *  Cinc client and Chef Cookbooks for ArcGIS must be installed on the target EC2 instances.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/aws/modules/s3_copy_files/main.tf
+++ b/aws/modules/s3_copy_files/main.tf
@@ -16,7 +16,7 @@
  * * My Esri user name and password must be specified either by environment variables ARCGIS_ONLINE_USERNAME and ARCGIS_ONLINE_PASSWORD or using the input variables.
  */
 
-# Copyright 2024 Esri
+# Copyright 2024-2026 Esri
 #
 # Licensed under the Apache License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/azure/arcgis-enterprise-base-windows/README.md
+++ b/azure/arcgis-enterprise-base-windows/README.md
@@ -62,8 +62,6 @@ Instructions:
 2. Commit the changes to a Git branch and push the branch to GitHub.
 3. Run the enterprise-base-windows-azure-image workflow using the branch.
 
-> In the configuration files, "os" and "arcgis_version" properties values for the same deployment must match across all the configuration files of the deployment.
-
 ### 3. Provision Azure Resources
 
 GitHub Actions workflow **enterprise-base-windows-azure-infrastructure** creates Azure resources for base ArcGIS Enterprise deployment.

--- a/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/application.tfvars.json
@@ -18,7 +18,6 @@
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
-  "os": "rhel9",
   "portal_authorization_file_path": "~/config/authorization/12.0/portal_120.json",
   "portal_user_license_type_id": "creatorUT",
   "root_cert_file_path": null,

--- a/config/aws/arcgis-enterprise-base-linux/infrastructure.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-linux/infrastructure.tfvars.json
@@ -6,11 +6,9 @@
   "instance_type": "m7i.2xlarge",
   "is_ha": true,
   "key_name": null,
-  "portal_web_context": "portal",
   "root_volume_size": 1024,
   "root_volume_iops": 16000,
   "root_volume_throughput": 1000,
-  "server_web_context": "server",
   "site_id": "arcgis",
   "subnet_ids": []
 }

--- a/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/application.tfvars.json
@@ -18,7 +18,6 @@
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
-  "os": "windows2025",
   "portal_authorization_file_path": "~/config/authorization/12.0/portal_120.json",
   "portal_user_license_type_id": "creatorUT",
   "root_cert_file_path": null,

--- a/config/aws/arcgis-enterprise-base-windows/infrastructure.tfvars.json
+++ b/config/aws/arcgis-enterprise-base-windows/infrastructure.tfvars.json
@@ -6,11 +6,9 @@
   "instance_type": "m7i.2xlarge",
   "is_ha": true,
   "key_name": null,
-  "portal_web_context": "portal",
   "root_volume_size": 1024,
   "root_volume_iops": 16000,
   "root_volume_throughput": 1000,
-  "server_web_context": "server",   
   "site_id": "arcgis",
   "subnet_ids": []
 }

--- a/config/aws/arcgis-notebook-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-notebook-server-linux/application.tfvars.json
@@ -14,7 +14,6 @@
   "log_level": "WARNING",
   "notebook_server_authorization_file_path": "~/config/authorization/12.0/notebook_server_120.prvc",
   "notebook_server_authorization_options": "",
-  "os": "rhel9",
   "portal_org_id": null,
   "root_cert_file_path": null,
   "run_as_user": "arcgis",

--- a/config/aws/arcgis-notebook-server-linux/infrastructure.tfvars.json
+++ b/config/aws/arcgis-notebook-server-linux/infrastructure.tfvars.json
@@ -6,7 +6,6 @@
   "instance_type": "m7i.2xlarge",
   "key_name": null,
   "node_count": 1,
-  "notebook_server_web_context": "notebooks",
   "portal_deployment_id": "enterprise-base-linux",
   "root_volume_iops": 16000,
   "root_volume_size": 1024,

--- a/config/aws/arcgis-server-linux/application.tfvars.json
+++ b/config/aws/arcgis-server-linux/application.tfvars.json
@@ -9,7 +9,6 @@
   "keystore_file_password": "",
   "keystore_file_path": null,
   "log_level": "WARNING",
-  "os": "rhel9",
   "portal_org_id": null,
   "root_cert_file_path": null,
   "run_as_user": "arcgis",

--- a/config/aws/arcgis-server-linux/infrastructure.tfvars.json
+++ b/config/aws/arcgis-server-linux/infrastructure.tfvars.json
@@ -10,7 +10,6 @@
   "root_volume_iops": 16000,
   "root_volume_size": 1024,
   "root_volume_throughput": 1000,
-  "server_web_context": "arcgis",
   "site_id": "arcgis",
   "subnet_ids": [],
   "use_webadaptor": true

--- a/config/aws/arcgis-site-core/ingress.tfvars.json
+++ b/config/aws/arcgis-site-core/ingress.tfvars.json
@@ -6,15 +6,8 @@
   "deployment_id": "enterprise-ingress",
   "enable_access_log": true,
   "hosted_zone_id": null,
-  "http_ports": [
-    80
-  ],
-  "https_ports": [
-    443,
-    6443,
-    7443,
-    11443
-  ],
+  "http_ports": [ 80 ],
+  "https_ports": [ 443 ],
   "internal_load_balancer": false,
   "site_id": "arcgis",
   "ssl_certificate_arn": "<ssl_certificate_arn>",


### PR DESCRIPTION
This PR updates the AWS (and some Azure docs) ArcGIS deployment automation to rely more on image-published SSM parameters (OS + web context), simplifies ingress/ALB routing to a single HTTPS entrypoint, and hardens CI/CD Terraform execution with non-interactive flags and additional validation.

**Changes:**
- Move several deployment attributes (OS + web-contexts) from tfvars/module inputs to SSM parameters written during AMI build and read during deploy.
- Simplify ALB target-group routing to use a single `web_context` input (removing explicit `path_patterns`) and standardize on port 443 in more places.
- Update workflows to run Terraform non-interactively (`-input=false`) and refresh copyrights/docs.

> The PR does not resolve #279 because AWS ALB does not yet support setting X-Forwarded-Host request header, which is required to use ALB as a reverse proxy for ArcGIS Server. It just prepares the templates to support configurations with and without ArcGIS Web Adaptor.