### PR TITLE
Update iam policies

### DIFF
--- a/aws/arcgis-enterprise-core/workflows/enterprise-ingress-aws-destroy.yaml
+++ b/aws/arcgis-enterprise-core/workflows/enterprise-ingress-aws-destroy.yaml
@@ -47,6 +47,6 @@ jobs:
       id: terraform-destroy
       run: |
         ENTERPRISE_ID=$(jq -r '.enterprise_id' $CONFIG_FILE)
-        DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
-        terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$ENTERPRISE_ID/aws/$DEPLOYMENT_ID/ingress.tfstate" -backend-config="region=$TF_VAR_aws_region" 
+        INGRESS_ID=$(jq -r '.ingress_id' $CONFIG_FILE)
+        terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$ENTERPRISE_ID/aws/$INGRESS_ID/ingress.tfstate" -backend-config="region=$TF_VAR_aws_region" 
         terraform destroy -var-file $CONFIG_FILE -auto-approve

--- a/aws/arcgis-enterprise-core/workflows/enterprise-ingress-aws.yaml
+++ b/aws/arcgis-enterprise-core/workflows/enterprise-ingress-aws.yaml
@@ -56,8 +56,8 @@ jobs:
       id: terraform-init
       run: |
         ENTERPRISE_ID=$(jq -r '.enterprise_id' $CONFIG_FILE)
-        DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
-        terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$ENTERPRISE_ID/aws/$DEPLOYMENT_ID/ingress.tfstate" -backend-config="region=$TF_VAR_aws_region" 
+        INGRESS_ID=$(jq -r '.ingress_id' $CONFIG_FILE)
+        terraform init -backend-config="bucket=$TERRAFORM_BACKEND_S3_BUCKET" -backend-config="key=$ENTERPRISE_ID/aws/$INGRESS_ID/ingress.tfstate" -backend-config="region=$TF_VAR_aws_region" 
     - name: Terraform Apply
       id: terraform-apply
       if: github.event.inputs.terraform_command != 'plan'

--- a/aws/iam-policies/ArcGISEnterpriseCore.json
+++ b/aws/iam-policies/ArcGISEnterpriseCore.json
@@ -18,6 +18,7 @@
                 "sns:GetSubscriptionAttributes",
                 "sns:ListTagsForResource",
                 "sns:SetTopicAttributes",
+                "sns:Subscribe",                
                 "sns:TagResource"
             ],
             "Resource": "*"

--- a/aws/iam-policies/ArcGISEnterpriseCoreDestroy.json
+++ b/aws/iam-policies/ArcGISEnterpriseCoreDestroy.json
@@ -15,7 +15,8 @@
                 "sns:DeleteTopic",
                 "sns:GetTopicAttributes",
                 "sns:GetSubscriptionAttributes",
-                "sns:ListTagsForResource"
+                "sns:ListTagsForResource",
+                "sns:Unsubscribe"
             ],
             "Resource": "*"
         },

--- a/azure/arcgis-enterprise-core/workflows/enterprise-ingress-azure-destroy.yaml
+++ b/azure/arcgis-enterprise-core/workflows/enterprise-ingress-azure-destroy.yaml
@@ -51,10 +51,10 @@ jobs:
         id: terraform-init
         run: |
           ENTERPRISE_ID=$(jq -r '.enterprise_id' $CONFIG_FILE)
-          DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
+          INGRESS_ID=$(jq -r '.ingress_id' $CONFIG_FILE)
           terraform init -backend-config="storage_account_name=$TERRAFORM_BACKEND_STORAGE_ACCOUNT_NAME" \
                          -backend-config="container_name=$TERRAFORM_BACKEND_CONTAINER_NAME" \
-                         -backend-config="key=$ENTERPRISE_ID/azure/$DEPLOYMENT_ID/ingress.tfstate"
+                         -backend-config="key=$ENTERPRISE_ID/azure/$INGRESS_ID/ingress.tfstate"
       - name: Terraform Destroy
         id: terraform-destroy
         run: terraform destroy -var-file $CONFIG_FILE -auto-approve -input=false

--- a/azure/arcgis-enterprise-core/workflows/enterprise-ingress-azure.yaml
+++ b/azure/arcgis-enterprise-core/workflows/enterprise-ingress-azure.yaml
@@ -58,10 +58,10 @@ jobs:
         id: terraform-init
         run: |
           ENTERPRISE_ID=$(jq -r '.enterprise_id' $CONFIG_FILE)
-          DEPLOYMENT_ID=$(jq -r '.deployment_id' $CONFIG_FILE)
+          INGRESS_ID=$(jq -r '.ingress_id' $CONFIG_FILE)
           terraform init -backend-config="storage_account_name=$TERRAFORM_BACKEND_STORAGE_ACCOUNT_NAME" \
                          -backend-config="container_name=$TERRAFORM_BACKEND_CONTAINER_NAME" \
-                         -backend-config="key=$ENTERPRISE_ID/azure/$DEPLOYMENT_ID/ingress.tfstate"
+                         -backend-config="key=$ENTERPRISE_ID/azure/$INGRESS_ID/ingress.tfstate"
       - name: Terraform Apply
         id: terraform-apply
         if: github.event.inputs.terraform_command != 'plan'


### PR DESCRIPTION
This pull request updates both AWS and Azure workflow files to use `ingress_id` instead of `deployment_id` for identifying ingress resources, ensuring consistency and correctness in Terraform state management. Additionally, it updates IAM policies to grant the necessary SNS permissions for subscribing and unsubscribing.

**Workflow improvements:**

* All `enterprise-ingress` workflows for AWS and Azure now use `ingress_id` instead of `deployment_id` to construct the Terraform state key, ensuring the correct resource is targeted during apply and destroy operations. (`aws/arcgis-enterprise-core/workflows/enterprise-ingress-aws.yaml`, `aws/arcgis-enterprise-core/workflows/enterprise-ingress-aws-destroy.yaml`, `azure/arcgis-enterprise-core/workflows/enterprise-ingress-azure.yaml`, `azure/arcgis-enterprise-core/workflows/enterprise-ingress-azure-destroy.yaml`) [[1]](diffhunk://#diff-2f8275ca4fbb8389737663e027976ae3c997f7ffb12e283ccaacc29c1a332589L59-R60) [[2]](diffhunk://#diff-7bb5da6ff2ea6c86d6713882fd8f85ab1d4a4421fef25866d2b38132393bcd08L50-R51) [[3]](diffhunk://#diff-d691933afced79ed887de4a8baa02d2885782bcd9ccc9294234339f84a08a854L61-R64) [[4]](diffhunk://#diff-84d7cfab117a4ee18e1a928417f9e8f1ceccccd6e3ae39630891656f0b72d86fL54-R57)

**IAM policy updates:**

* The `ArcGISEnterpriseCore` policy now allows the `sns:Subscribe` action, enabling subscription to SNS topics. (`aws/iam-policies/ArcGISEnterpriseCore.json`)
* The `ArcGISEnterpriseCoreDestroy` policy now allows the `sns:Unsubscribe` action, supporting cleanup of SNS subscriptions during resource destruction. (`aws/iam-policies/ArcGISEnterpriseCoreDestroy.json`)